### PR TITLE
Goldpbear/map pin spotlight

### DIFF
--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -530,7 +530,11 @@ a.logout-btn {
   height: 100%;
   width: 100%;
   margin: 0 auto;
-  opacity: .4;
+  /* for IE */
+  filter: alpha(opacity=40);
+  -moz-opacity:0.4;
+  -khtml-opacity: 0.4;
+  opacity: 0.4;
 }
 
 #new-place-mask-fill {

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -530,17 +530,20 @@ a.logout-btn {
   height: 100%;
   width: 100%;
   margin: 0 auto;
-  opacity: .8;
+  opacity: .4;
 }
 
-#new-place-mask:after{
+#new-place-mask-fill {
   content: '';
   position: absolute;
-  left: 38%; 
-  top: 32%;
+  /*left: 38%; 
+  top: 32%;*/
   border-radius: 50%;
-  width: 200px; 
-  height: 200px;
+  /*width: 200px; 
+  height: 200px;*/
+  -webkit-appearance: none;
+  -webkit-box-shadow: 0px 0px 0px 2000px #222222;
+  -moz-box-shadow: 0px 0px 0px 2000px #222222;
   box-shadow: 0px 0px 0px 2000px #222222;
 }
 

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -541,9 +541,9 @@ a.logout-btn {
   /*width: 200px; 
   height: 200px;*/
   -webkit-appearance: none;
-  -webkit-box-shadow: 0px 0px 0px 2000px #222222;
-  -moz-box-shadow: 0px 0px 0px 2000px #222222;
-  box-shadow: 0px 0px 0px 2000px #222222;
+  -webkit-box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
+  -moz-box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
+  box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
 }
 
 .mask {

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -531,10 +531,12 @@ a.logout-btn {
   width: 100%;
   margin: 0 auto;
   /* for IE */
+  /*
   filter: alpha(opacity=40);
   -moz-opacity:0.4;
   -khtml-opacity: 0.4;
   opacity: 0.4;
+  */
 }
 
 #new-place-mask-fill {

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -534,7 +534,6 @@ a.logout-btn {
 }
 
 #new-place-mask-fill {
-  content: '';
   position: absolute;
   /*left: 38%; 
   top: 32%;*/
@@ -1854,7 +1853,7 @@ browser height, but in portrait mode, we usually have ~30px of nav/status-bar, s
     position: absolute;
     top: 4em; /* height of #site-header */
     right: 0;
-    bottom: 1.75em;
+    bottom: 0;
     left: 0;
   }
   .content-visible #map-container {

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -535,15 +535,7 @@ a.logout-btn {
 
 #new-place-mask-fill {
   position: absolute;
-  /*left: 38%; 
-  top: 32%;*/
   border-radius: 50%;
-  /*width: 200px; 
-  height: 200px;*/
-  -webkit-appearance: none;
-  -webkit-box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
-  -moz-box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
-  box-shadow: 0px 0px 0px 2000px #222222, inset 0px 0px 20px 30px #222222;
 }
 
 .mask {

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -474,6 +474,8 @@ a.logout-btn {
 #map {
   background: #a3c7d9;
   height: 150px;
+
+  /*opacity: 0.5;*/
 }
 
 /* Geolocation Button */
@@ -519,10 +521,42 @@ a.logout-btn {
   left: 50%;
   pointer-events: none;
   z-index: 11;
-  width: 47px;
-  height: 47px;
+  width: 100px;
+  height: 100px;
   margin: -44px 0 0 -12px;
 }
+
+#new-place-mask {
+  height: 100%;
+  width: 100%;
+  margin: 0 auto;
+  opacity: .8;
+}
+
+#new-place-mask:after{
+  content: '';
+  position: absolute;
+  left: 38%; 
+  top: 32%;
+  border-radius: 50%;
+  width: 200px; 
+  height: 200px;
+  box-shadow: 0px 0px 0px 2000px #222222;
+}
+
+.mask {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  background-color: red;
+}
+
+.mask-left {
+  left: 0%;
+  width: 200px;
+  height: 200px;
+}
+
 #centerpoint.newpin .x {
   display: block;
   position: absolute;

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -773,8 +773,16 @@ var Shareabouts = Shareabouts || {};
     },
     showNewPin: function() {
       this.$centerpoint.show().addClass('newpin');
+      var spotlightDiameter = 200,
+          xOffset = $("#map").width() / 2 - (spotlightDiameter / 2),
+          yOffset = $("#map").height() / 2 - (spotlightDiameter / 2);
+
       // add html for masking the map
-      $("#map").append("<div id='new-place-mask'><div>");
+      $("#map").append("<div id='new-place-mask'><div id='new-place-mask-fill'></div></div>");
+      $("#new-place-mask-fill").css("left", xOffset + "px")
+                               .css("top", yOffset + "px")
+                               .css("width", spotlightDiameter + "px")
+                               .css("height", spotlightDiameter + "px");
     },
     showAddButton: function() {
       this.$addButton.show();

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -784,7 +784,7 @@ var Shareabouts = Shareabouts || {};
                                .css("width", spotlightDiameter + "px")
                                .css("height", spotlightDiameter + "px")
                                // scale the box shadow to the largest screen dimension; an arbitrarily large box shadow won't get drawn in Safari
-                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px #222222, inset 0px 0px 20px 30px #222222");
+                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px, inset 0px 0px 20px 30px");
     },
     showAddButton: function() {
       this.$addButton.show();

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -782,7 +782,9 @@ var Shareabouts = Shareabouts || {};
       $("#new-place-mask-fill").css("left", xOffset + "px")
                                .css("top", yOffset + "px")
                                .css("width", spotlightDiameter + "px")
-                               .css("height", spotlightDiameter + "px");
+                               .css("height", spotlightDiameter + "px")
+                               // scale the box shadow to the largest screen dimension; an arbitrarily large box shadow won't get drawn in Safari
+                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px #222222, inset 0px 0px 20px 30px #222222");
     },
     showAddButton: function() {
       this.$addButton.show();

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -363,6 +363,8 @@ var Shareabouts = Shareabouts || {};
       // Never set the placeFormView's latLng until the user does it with a
       // drag event (below)
       if (this.placeFormView && this.placeFormView.center) {
+        // remove map mask once the user has dragged and set a location
+        $("#new-place-mask").remove();
         this.setPlaceFormViewLatLng(ll);
       }
 
@@ -381,6 +383,8 @@ var Shareabouts = Shareabouts || {};
     onClickClosePanelBtn: function(evt) {
       evt.preventDefault();
       S.Util.log('USER', 'panel', 'close-btn-click');
+      // remove map mask if the user closes the side panel
+      $("#new-place-mask").remove();
       if (this.mapView.locationTypeFilter) {
         this.options.router.navigate('filter/' + this.mapView.locationTypeFilter, {trigger: true});
       } else {
@@ -769,6 +773,8 @@ var Shareabouts = Shareabouts || {};
     },
     showNewPin: function() {
       this.$centerpoint.show().addClass('newpin');
+      // add html for masking the map
+      $("#map").append("<div id='new-place-mask'><div>");
     },
     showAddButton: function() {
       this.$addButton.show();

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -773,11 +773,11 @@ var Shareabouts = Shareabouts || {};
     },
     showNewPin: function() {
       this.$centerpoint.show().addClass('newpin');
+
+      // add map mask and spotlight effect
       var spotlightDiameter = 200,
           xOffset = $("#map").width() / 2 - (spotlightDiameter / 2),
           yOffset = $("#map").height() / 2 - (spotlightDiameter / 2);
-
-      // add html for masking the map
       $("#map").append("<div id='new-place-mask'><div id='new-place-mask-fill'></div></div>");
       $("#new-place-mask-fill").css("left", xOffset + "px")
                                .css("top", yOffset + "px")

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -784,7 +784,7 @@ var Shareabouts = Shareabouts || {};
                                .css("width", spotlightDiameter + "px")
                                .css("height", spotlightDiameter + "px")
                                // scale the box shadow to the largest screen dimension; an arbitrarily large box shadow won't get drawn in Safari
-                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px, inset 0px 0px 20px 30px");
+                               .css("box-shadow", "0px 0px 0px " + Math.max((yOffset * 2), (xOffset * 2)) + "px rgba(0,0,0,0.4), inset 0px 0px 20px 30px rgba(0,0,0,0.4)");
     },
     showAddButton: function() {
       this.$addButton.show();

--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -120,9 +120,11 @@
     {% endif %}
 
     <div id="map-container">
+      
       <div id="ajax-error-msg">{% blocktrans %}We can't connect to the server at the moment. Hang tight while we re-establish communication.{% endblocktrans %}</div>
       <div id="map-progress" class="progress-bar"><strong>Loading Data&hellip;</strong><span class="current-progress"></span></div>
       <div id="map"></div>
+      
 
       {% if config.leaflet_sidebar.enabled %}
         <div id="sidebar" class="sidebar collapsed">

--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -185,9 +185,11 @@
 
   <div id="list-container"></div>
 
+  <!--
   <footer id="colophon">
     {% block colophon %}{% endblock %}
   </footer>
+  -->
 
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>


### PR DESCRIPTION
This branch implements a feathered spotlight effect around the map pin when a user clicks the new report button. The spotlight will automatically re-center if the map dimensions are changed (although not as the user drags the browser window to new dimensions--only when the add report button is clicked again at the new dimensions). I haven't been able to test this on IE or phones yet.