### PR TITLE
Fix some bugs for Willamette flavor

### DIFF
--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -64,7 +64,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: '{{map.zoom}} < 14'
         icon:
           iconUrl: /static/css/images/markers/dot-0d85e9.png
           iconSize: [10, 12]
@@ -88,7 +88,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: '{{map.zoom}} < 14'
         icon:
           iconUrl: /static/css/images/markers/dot-dbcf2c.png
           iconSize: [10, 12]
@@ -112,7 +112,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: '{{map.zoom}} < 14'
         icon:
           iconUrl: /static/css/images/markers/dot-f95016.png
           iconSize: [10, 12]
@@ -136,7 +136,7 @@ place_types:
           shadowSize: [50, 60]
           shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 11'
+      - condition: '{{map.zoom}} < 14'
         icon:
           iconUrl: /static/css/images/markers/marker-complaint.png
           iconSize: [10, 12]

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -23,7 +23,7 @@ map:
   geolocation_enabled: true
   geolocation_onload: false
 
-  geocoding_enabled: true
+  geocoding_enabled: false
   geocode_field_label: _(Enter an address...)
   geocode_bounding_box: [39.830159, -75.478821, 40.167331, -74.781189]  # top, left, bottom, right
 


### PR DESCRIPTION
couple of bugs on the new Willamette flavor: 

 * Report icons don't show up between zooms 11 and 13
 * The location of a newly added report isn't accurately set