### PR TITLE
Goldpbear/backbone model refactor

### DIFF
--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -9,11 +9,14 @@ var Shareabouts = Shareabouts || {};
       'filter/:locationtype': 'filterMap',
       'page/:slug': 'viewPage',
       ':dataset/new': 'newPlace',
+      // REFACTOR
+      // I replaced some url paths below with a generic function, "viewPlaceOrLandmark," which
+      // decides whether to route to viewPlace or viewLandmark
       ':dataset/:id': 'viewPlaceOrLandmark',
       ':dataset/:id/response/:response_id': 'viewPlaceOrLandmark',
       ':dataset/:id/edit': 'editPlace',
       'list': 'showList',
-      ':id': 'viewLandmark',
+      ':id': 'viewPlaceOrLandmark',
       ':zoom/:lat/:lng': 'viewMap'
     },
 
@@ -22,7 +25,10 @@ var Shareabouts = Shareabouts || {};
           startPageConfig,
           filteredRoutes;
 
-      // object for storing all collections, including shareabouts places and landmarks
+      // REFACTOR
+      // This object stores all collections, including shareabouts places and landmarks.
+      // Here, it's initialized with a key-value pair for shareabouts data. Landmark collections
+      // are added below (~line 85)
       this.collection = {
         "places": new S.PlaceCollection([])
       };
@@ -73,6 +79,9 @@ var Shareabouts = Shareabouts || {};
       var landmarkConfigs = {};
       _.each(landmarkConfigsArray, function(landmarkConfig) {
         var collectionId = landmarkConfig['id'];
+        // REFACTOR
+        // Each config layer with type landmark gets added as a property (with key equal to id) 
+        // to the collection object here:
         var collection = new S.LandmarkCollection([]);
         collection.url = landmarkConfig.url;
         self.collection[collectionId] = collection;
@@ -141,6 +150,8 @@ var Shareabouts = Shareabouts || {};
 
     // Open view for first step in multi-step form
     newPlace: function() {
+      console.log("newPlace");
+
       this.appView.newPlace();
     },
 
@@ -151,7 +162,13 @@ var Shareabouts = Shareabouts || {};
     },
 
     // decide whether to route to the place view or the landmark view
+    // REFACTOR
+    // This method replaces viewLandmark and viewPlace
     viewPlaceOrLandmark: function(datasetSlug, id, responseId) {
+      console.log("viewPlaceOrLandmark");
+
+      // REFACTOR
+      // Using hard-coded values here to decide whether to route to viewPlace
       if (datasetSlug == "report" || datasetSlug == "place") {
         this.appView.viewPlace(id, responseId, this.loading);
       } else {

--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -22,6 +22,11 @@ var Shareabouts = Shareabouts || {};
           startPageConfig,
           filteredRoutes;
 
+      // object for storing all collections, including shareabouts places and landmarks
+      this.collection = {
+        "places": new S.PlaceCollection([])
+      };
+
       if (!options.placeConfig.dataset_slug) {
         options.placeConfig.dataset_slug = 'place';
       }
@@ -39,7 +44,7 @@ var Shareabouts = Shareabouts || {};
             locationTypes = _.map(S.Config.placeTypes, function(config, key){ return key; });
 
         if (!_.contains(locationTypes, locationType)) {
-          console.warn(locationType + ' is not supported.');
+          //console.warn(locationType + ' is not supported.');
           return locationType + ' is not supported.';
         }
       };
@@ -59,11 +64,9 @@ var Shareabouts = Shareabouts || {};
       }, this);
 
       this.loading = true;
-      this.collection = new S.PlaceCollection([]);
+      //this.collection = new S.PlaceCollection([]);
       this.activities = new S.ActionCollection(options.activity);
 
-
-      this.landmarkCollections = {};
       var landmarkConfigsArray = options.mapConfig.layers.filter(function(layer) {
         return layer.type && layer.type === 'landmark';
       });
@@ -72,7 +75,7 @@ var Shareabouts = Shareabouts || {};
         var collectionId = landmarkConfig['id'];
         var collection = new S.LandmarkCollection([]);
         collection.url = landmarkConfig.url;
-        self.landmarkCollections[collectionId] = collection;
+        self.collection[collectionId] = collection;
         landmarkConfigs[collectionId] = landmarkConfig;
       });
 
@@ -81,7 +84,7 @@ var Shareabouts = Shareabouts || {};
         collection: this.collection,
         activities: this.activities,
 
-        landmarkCollections: this.landmarkCollections,
+        //landmarkCollections: this.landmarkCollections,
         landmarkConfigs: landmarkConfigs,
 
         config: options.config,
@@ -123,6 +126,9 @@ var Shareabouts = Shareabouts || {};
     getCurrentPath: function() {
       var root = Backbone.history.root,
           fragment = Backbone.history.fragment;
+
+      console.log("root:", root);
+      console.log("fragment:", fragment);
       return root + fragment;
     },
 
@@ -142,10 +148,15 @@ var Shareabouts = Shareabouts || {};
     },
 
     viewLandmark: function(id) {
+      console.log("view landmark");
+
       this.appView.viewLandmark(id, { zoom: this.loading });
     },
 
     viewPlace: function(datasetSlug, id, responseId) {
+      console.log("view place");
+      console.log(datasetSlug);
+
       // TODO: When we handle multiple datasets, we will need to
       // implement appView.viewPlace(..) to accept a datasetSlug parameter
       this.appView.viewPlace(id, responseId, this.loading);

--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -172,6 +172,7 @@ var Shareabouts = Shareabouts || {};
       if (datasetSlug == "report" || datasetSlug == "place") {
         this.appView.viewPlace(id, responseId, this.loading);
       } else {
+        console.log("routes datasetSlug", datasetSlug);
         this.appView.viewLandmark(datasetSlug, id, { zoom: this.loading });
       }
     },

--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -9,8 +9,8 @@ var Shareabouts = Shareabouts || {};
       'filter/:locationtype': 'filterMap',
       'page/:slug': 'viewPage',
       ':dataset/new': 'newPlace',
-      ':dataset/:id': 'viewPlace',
-      ':dataset/:id/response/:response_id': 'viewPlace',
+      ':dataset/:id': 'viewPlaceOrLandmark',
+      ':dataset/:id/response/:response_id': 'viewPlaceOrLandmark',
       ':dataset/:id/edit': 'editPlace',
       'list': 'showList',
       ':id': 'viewLandmark',
@@ -126,9 +126,6 @@ var Shareabouts = Shareabouts || {};
     getCurrentPath: function() {
       var root = Backbone.history.root,
           fragment = Backbone.history.fragment;
-
-      console.log("root:", root);
-      console.log("fragment:", fragment);
       return root + fragment;
     },
 
@@ -153,13 +150,22 @@ var Shareabouts = Shareabouts || {};
       this.appView.viewLandmark(id, { zoom: this.loading });
     },
 
+    // decide whether to route to the place view or the landmark view
+    viewPlaceOrLandmark: function(datasetSlug, id, responseId) {
+      if (datasetSlug == "report" || datasetSlug == "place") {
+        this.appView.viewPlace(id, responseId, this.loading);
+      } else {
+        this.appView.viewLandmark(datasetSlug, id, { zoom: this.loading });
+      }
+    },
+
     viewPlace: function(datasetSlug, id, responseId) {
       console.log("view place");
       console.log(datasetSlug);
 
       // TODO: When we handle multiple datasets, we will need to
       // implement appView.viewPlace(..) to accept a datasetSlug parameter
-      this.appView.viewPlace(id, responseId, this.loading);
+      this.appView.viewPlace(datasetSlug, id, responseId, this.loading);
     },
 
     editPlace: function(){},

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -91,10 +91,10 @@ var Shareabouts = Shareabouts || {};
       });
 
       // Handle collection events
-      _.each(this.collection, function(collection) {
-        collection.on('add', this.onAddPlace, this);
-        collection.on('remove', this.onRemovePlace, this);
-      });
+      // REFACTOR
+      // bind add and remove events explicity to the places property of the collections object:
+      this.collection.places.on('add', this.onAddPlace, this);
+      this.collection.places.on('remove', this.onRemovePlace, this);
       
       // On any route (/place or /page), hide the list view
       this.options.router.bind('route', function(route) {
@@ -403,8 +403,12 @@ var Shareabouts = Shareabouts || {};
     // This gets called for every model that gets added to the place
     // collection, not just new ones.
     onAddPlace: function(model) {
+      console.log("onAddPlace");
+
       // If it's new, then show the form in order to edit and save it.
       if (model.isNew()) {
+
+        console.log("model", model);
 
         this.placeFormView = new S.PlaceFormView({
           model: model,
@@ -519,10 +523,13 @@ var Shareabouts = Shareabouts || {};
       this.setBodyClass();
     },
     newPlace: function() {
+      console.log("appView.newPlace");
       // Called by the router
-      this.collection.add({});
+      this.collection.places.add({});
     },
 
+    // REFACTOR
+    // add a datasetSlug parameter here, which corresponds to the id property from config.yml
     viewLandmark: function(datasetSlug, model, options) {
       console.log("appView viewLandmark");
 
@@ -535,8 +542,6 @@ var Shareabouts = Shareabouts || {};
         var map = self.mapView.map,
             layer, center, landmarkDetailView, $responseToScrollTo;
         options = newOptions ? newOptions : options;
-
-        console.log("self.mapView", self.mapView);
 
         layer = self.mapView.layerViews[options.collectionId][model.id].layer
 
@@ -623,14 +628,14 @@ var Shareabouts = Shareabouts || {};
 
       // Otherwise, assume we have a model ID.
       modelId = model;
+      // REFACTOR
+      // fetch the collection using datasetSlug
       var landmarkCollection = this.collection[datasetSlug];
       if (!landmarkCollection) {
         onLandmarkNotFound();
         return;
       }
       model = landmarkCollection.get(modelId);
-
-      console.log("!!!", model);
 
       // If the model was found in the landmarks, go ahead and use it.
       if (model) {

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -250,9 +250,9 @@ var Shareabouts = Shareabouts || {};
       this.placeFormView = null;
       this.placeDetailViews = {};
       this.landmarkDetailViews = {};
-      //_.each(Object.keys(this.landmarkCollections), function(collectionId) {
-      //  self.landmarkDetailViews[collectionId] = {};
-      //});
+      _.each(Object.keys(this.collection), function(collectionId) {
+        self.landmarkDetailViews[collectionId] = {};
+      });
 
       // Show tools for adding data
       this.setBodyClass();
@@ -522,21 +522,23 @@ var Shareabouts = Shareabouts || {};
       // Called by the router
       this.collection.add({});
     },
-    // TODO: Refactor this into 'viewPlace'
-    viewLandmark: function(model, options) {
+
+    viewLandmark: function(datasetSlug, model, options) {
+      console.log("appView viewLandmark");
+
       var self = this,
           includeSubmissions = S.Config.flavor.app.list_enabled !== false,
           layout = S.Util.getPageLayout(),
           onLandmarkFound, onLandmarkNotFound, modelId;
-
-      console.log(this);
 
       onLandmarkFound = function(model, response, newOptions) {
         var map = self.mapView.map,
             layer, center, landmarkDetailView, $responseToScrollTo;
         options = newOptions ? newOptions : options;
 
-        layer = self.mapView.landmarkLayerViews[options.collectionId][model.id].layer
+        console.log("self.mapView", self.mapView);
+
+        layer = self.mapView.layerViews[options.collectionId][model.id].layer
 
         if (layer) {
           center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
@@ -590,7 +592,7 @@ var Shareabouts = Shareabouts || {};
         var collectionId;
         _.find(Object.keys(self.options.landmarkConfigs), function(landmarkConfigId) {
           collectionId = landmarkConfigId;
-          cachedModel = self.landmarkCollections[landmarkConfigId].get(model);
+          cachedModel = self.collection[datasetSlug].get(model);
           return cachedModel;
         });
         if (cachedModel) {
@@ -621,12 +623,14 @@ var Shareabouts = Shareabouts || {};
 
       // Otherwise, assume we have a model ID.
       modelId = model;
-      var landmarkCollection = this.landmarkCollections[options.collectionId];
+      var landmarkCollection = this.collection[datasetSlug];
       if (!landmarkCollection) {
         onLandmarkNotFound();
         return;
       }
       model = landmarkCollection.get(modelId);
+
+      console.log("!!!", model);
 
       // If the model was found in the landmarks, go ahead and use it.
       if (model) {
@@ -728,8 +732,6 @@ var Shareabouts = Shareabouts || {};
 
       // Otherwise, assume we have a model ID.
       modelId = model;
-
-      console.log("!!", this);
 
       model = this.places.get(modelId);
 

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -284,8 +284,8 @@ var Shareabouts = Shareabouts || {};
     loadLandmarks: function() {
       var self = this;
 
-      console.log("this.options.landmarkConfigs", this.options.landmarkConfigs);
-
+      // REFACTOR
+      // Here's where I'm adding the datasetSlug value for landmark places
       _.each(this.options.landmarkConfigs, function(value, key) {
         if (value.placeType) {
           self.collection[landmarkConfig.id].fetch({
@@ -589,6 +589,9 @@ var Shareabouts = Shareabouts || {};
         }
       };
 
+      console.log("self.options.landmarkConfigs", self.options.landmarkConfigs);
+      console.log("datasetSlug", datasetSlug);
+
       // If a collectionId is not specified, then we need to search all collections
       if (options['collectionId'] === undefined) {
         // First, let's check the caches of all of our collections for the
@@ -597,6 +600,7 @@ var Shareabouts = Shareabouts || {};
         var collectionId;
         _.find(Object.keys(self.options.landmarkConfigs), function(landmarkConfigId) {
           collectionId = landmarkConfigId;
+
           cachedModel = self.collection[datasetSlug].get(model);
           return cachedModel;
         });

--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -25,6 +25,9 @@ var Shareabouts = Shareabouts || {};
 
       // Init the layer view caches
       // TODO: merge these two objects and manage them as one
+      // 
+      // REFACTOR
+      // all layer views are now stored in this object:
       this.layerViews = {}; // Maps our model id's to our place collection's model instances
       //this.landmarkLayerViews = {}; // Maps our landmark collection id to an objects that maps the id's to the model instances
 
@@ -44,6 +47,8 @@ var Shareabouts = Shareabouts || {};
           if (config.visibleDefault) {
             self.map.addLayer(self.layers[collectionId]);
           }
+          // REFACTOR
+          // add landmark layer views to the layerViews object:
           self.layerViews[collectionId] = {};
 
           // Bind our landmark data events:
@@ -311,11 +316,17 @@ var Shareabouts = Shareabouts || {};
     },
 
     clearFilter: function() {
+      console.log("clearFilter");
+
       var self = this;
       this.locationTypeFilter = null;
 
+      // REFACTOR
+      // Not too sure about this part of the code... I replaced the commented-out section below
+      // with to loops that iterate through all collections in the collection object, and all models
+      // within those collections
       _.each(this.collection, function(collection) {
-        _.each(collection, function(model) {
+        _.each(collection.models, function(model) {
           self.layerViews[model.cid].render();
         });
       });

--- a/src/sa_web/static/js/views/place-counter-view.js
+++ b/src/sa_web/static/js/views/place-counter-view.js
@@ -7,12 +7,12 @@ var Shareabouts = Shareabouts || {};
     initialize: function() {
       var self = this;
 
-      self.numberOfPlaces = this.collection.models.length;
+      self.numberOfPlaces = this.collection.places.models.length;
 
       // Bind data events
-      self.collection.on('reset', self.render, self);
-      self.collection.on('add', self.incrementPlaces, self);
-      self.collection.on('remove', self.decrementPlaces, self);
+      self.collection.places.on('reset', self.render, self);
+      self.collection.places.on('add', self.incrementPlaces, self);
+      self.collection.places.on('remove', self.decrementPlaces, self);
     },
     incrementPlaces: function() {
       this.numberOfPlaces++;
@@ -24,7 +24,7 @@ var Shareabouts = Shareabouts || {};
     },
     render: function() {
       var data = {
-        length: S.TemplateHelpers.formatNumber(this.collection.models.length),
+        length: S.TemplateHelpers.formatNumber(this.collection.places.models.length),
         meter_config: this.options.mapConfig,
         value: this.numberOfPlaces,
         value_pretty: S.TemplateHelpers.formatNumber(this.numberOfPlaces),

--- a/src/sa_web/static/js/views/place-counter-view.js
+++ b/src/sa_web/static/js/views/place-counter-view.js
@@ -7,6 +7,8 @@ var Shareabouts = Shareabouts || {};
     initialize: function() {
       var self = this;
 
+      // REFACTOR
+      // here and other places below I've hard-coded the places property of the collection object
       self.numberOfPlaces = this.collection.places.models.length;
 
       // Bind data events

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -115,6 +115,8 @@ var Shareabouts = Shareabouts || {};
         return;
       }
 
+      console.log("this.model", this.model.get('datasetSlug'));
+
       var router = this.options.router,
           model = this.model,
           // Should not include any files


### PR DESCRIPTION
Rough first stab at refactoring backbone collections into a single object, facilitating cleaner urls. I added comments (with the word "REFACTOR" to make them easy to find) explaining what I tried to do. A couple of obvious issues exist-- typing in direct paths to refactored landmark urls does not take the user to that landmark (this is probably an issue with making the API call incorrectly), and landmark icons do not resize properly when clicking from icon to icon for some reason.