### PR TITLE
goldpbear/spotlight bug fix

### DIFF
--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -807,6 +807,7 @@ var Shareabouts = Shareabouts || {};
       $("#add-place-btn-container").attr("class", "pos-top-right");
 
       S.Util.log('APP', 'panel-state', 'closed');
+      $("#spotlight-place-mask").remove();
     },
     hideNewPin: function() {
       this.showCenterPoint();


### PR DESCRIPTION
Quick fix for a bug that will cause the spotlight mask to remain after returning to the map view from the place detail view.