### PR TITLE
Fix deployment bug

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -52,7 +52,6 @@ shell.cat([
   'src/sa_web/static/js/views/place-detail-view.js',
   'src/sa_web/static/js/views/landmark-detail-view.js',
   'src/sa_web/static/js/views/place-form-view.js',
-  'src/sa_web/static/js/views/dataset-form-view.js',
   'src/sa_web/static/js/views/place-list-view.js',
   'src/sa_web/static/js/views/map-view.js',
   'src/sa_web/static/js/views/legend-view.js',
@@ -65,7 +64,7 @@ shell.cat([
 
 shell.cat([
   'src/sa_web/static/js/utils.js',
-  'src/sa_web/static/js/template-helpers.js'
+  'src/sa_web/static/js/template-helpers.js',
 ]).to('src/sa_web/static/dist/cat-preload-bundle.js')
 
 shell.cat([


### PR DESCRIPTION
`npm run build` will error out if a flavor doesn't have a `static/js/views` directory and a `static/css`, so this PR fixes that.

Removed the `dataset-form-view` view, which no longer exists. 