### PR TITLE
Dynamic form single category

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -52,7 +52,6 @@ shell.cat([
   'src/sa_web/static/js/views/place-detail-view.js',
   'src/sa_web/static/js/views/landmark-detail-view.js',
   'src/sa_web/static/js/views/place-form-view.js',
-  'src/sa_web/static/js/views/dataset-form-view.js',
   'src/sa_web/static/js/views/place-list-view.js',
   'src/sa_web/static/js/views/map-view.js',
   'src/sa_web/static/js/views/legend-view.js',
@@ -65,7 +64,7 @@ shell.cat([
 
 shell.cat([
   'src/sa_web/static/js/utils.js',
-  'src/sa_web/static/js/template-helpers.js'
+  'src/sa_web/static/js/template-helpers.js',
 ]).to('src/sa_web/static/dist/cat-preload-bundle.js')
 
 shell.cat([

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -642,10 +642,10 @@ var Shareabouts = Shareabouts || {};
         // If the model is not already in our collections, then we must fetch it
         // by making a call to each collection:
         var stillSearching = {};
-        _.each(self.options.landmarkConfigs, function(landmarkConfig) {
+        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
           stillSearching[landmarkConfig.id] = true;
         });
-        _.each(self.options.landmarkConfigs, function(landmarkConfig) {
+        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
           self.viewLandmark(model, { collectionId: landmarkConfig.id,
                                      zoom: options.zoom,
                                      stillSearching: stillSearching });
@@ -661,7 +661,7 @@ var Shareabouts = Shareabouts || {};
 
       // Otherwise, assume we have a model ID.
       modelId = model;
-      var landmarkCollection = this.landmarkCollections[options.collectionId];
+      var landmarkCollection = this.landmarks[options.collectionId];
       if (!landmarkCollection) {
         onLandmarkNotFound();
         return;


### PR DESCRIPTION
Fixes issue #373 -- should be ready to merge.

This PR changes the dynamic form behavior when only a single form category is active. With only a single category, the form will skip the category selection stage and immediately render the form for the relevant category.

Active category status is controlled via the `includeOnForm` flag (set to either `true` or `false`) under each dynamic form category's section in the config.

This PR adds a `postRender()` method to `place-form-view.js`, which can be used to perform functionality after the view's rendered Handlebars content has been inserted into the DOM.