### PR TITLE
Goldpbear/dynamic form single category

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -637,9 +637,9 @@ place:
 
 
   #### begin dynamic form config ####
-  #TODO: maybe add an autocomplete
-  categories:
+  place_detail:
     observation:
+      includeOnForm: false
       name: location_type
       dataset: duwamish
       datasetSlug: report
@@ -675,227 +675,232 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    # question:
-    #   name: location_type
-    #   dataset: duwamish
-    #   datasetSlug: report
-    #   icon_url: /static/css/images/markers/marker-question.png
-    #   value: question
-    #   label: _(Question)
-    #   fields:
-    #     - name: title
-    #       type: text
-    #       prompt: _(Title of your question:)
-    #       display_prompt: _(Title:)
-    #       placeholder: _(Enter title...)
-    #       optional: false
-    #     - name: description
-    #       type: textarea
-    #       prompt: "_(What's your question?)"
-    #       display_prompt: _(My question:)
-    #       placeholder: _(Enter question...)
-    # idea:
-    #   name: location_type
-    #   dataset: duwamish
-    #   datasetSlug: report
-    #   icon_url: /static/css/images/markers/marker-idea.png
-    #   value: idea
-    #   label: _(Idea)
-    #   fields:
-    #     - name: title
-    #       type: text
-    #       prompt: _(Title of your idea:)
-    #       placeholder: _(Enter title...)
-    #       display_prompt: _(Title:)
-    #       optional: false
-    #     - name: description
-    #       type: textarea
-    #       prompt: _(Describe your idea below:)
-    #       display_prompt: "_(Here's my idea:)"
-    #       placeholder: _(Description...)
-    #       optional: false
-    # complaint:
-    #   name: location_type
-    #   dataset: duwamish
-    #   datasetSlug: report
-    #   icon_url: /static/css/images/markers/marker-complaint.png
-    #   value: complaint
-    #   label: _(Complaint)
-    #   fields:
-    #     - name: title
-    #       type: text
-    #       prompt: _(Title of your complaint:)
-    #       placeholder: _(Enter title...)
-    #       display_prompt: _(Title:)
-    #       optional: false
-    #     - name: description
-    #       type: textarea
-    #       prompt: "_(What's your complaint?)"
-    #       display_prompt: _(I have the following complaint:)
-    #       placeholder: _(Description...)
-    #       optional: false
-    # air_watch:  #defines a top-level form category
-    #   name: location_type  #needs to be "location_type"
-    #   dataset: air
-    #   datasetSlug: air
-    #   icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
-    #   value: air_watch  #internal value used for this category
-    #   label: _(Air watch)  #label for this category
-    #   fields:  #field types can be: "dropdown", "radio_big_buttons", "checkbox_big_buttons", "yes_only_big_button", "text", or "textarea"
-    #     - name: date_time_observed 
-    #       type: datetime  
-    #       prompt: _(When did you observe these conditions?)
-    #       display_prompt: _(I observed these conditions on:)
-    #       optional: true
-    #     - name: reside_work_georgetown  
-    #       type: binary_toggle 
-    #       prompt: _(Do you reside and/or work in the Georgetown or South Park Neighborhood?)
-    #       display_prompt: _(I reside or work in Georgetown or South Park:)
-    #       content:
-    #         - label: _(Yes)
-    #           value: "yes"
-    #         - label: _(No)
-    #           value: "no"
-    #       optional: true # NOTE: binary_toggle inputs have no validation
-    #     - name: odd_smell
-    #       type: binary_toggle 
-    #       prompt: _(I observe an odd smell)
-    #       display_prompt: _(I observed an odd smell:)
-    #       content:
-    #         - label: _(Yes)
-    #           value: "yes"
-    #         - label: _(No)
-    #           value: "no"
-    #       annotation: _(Please be sure to seek medical attention if needed.)
-    #       optional: true
-    #     - name: burning
-    #       type: binary_toggle
-    #       prompt: _(I have burning or itching eyes/nose/skin)
-    #       display_prompt: _(I have burning or itching eyes/nose/skin:)
-    #       content:
-    #         - label: _(Yes)
-    #           value: "yes"
-    #         - label: _(No)
-    #           value: "no"
-    #       annotation: _(Please be sure to seek medical attention if needed.)
-    #       optional: true
-    #     - name: difficulty_breathing
-    #       type: binary_toggle
-    #       prompt: _(I am having difficulty breathing)
-    #       display_prompt: _(I am having difficulty breathing:)
-    #       content:
-    #         - label: _(Yes)
-    #           value: "yes"
-    #         - label: _(No)
-    #           value: "no"
-    #       annotation: _(Please be sure to seek medical attention if needed.)
-    #       optional: true
-    #     - name: headache
-    #       type: binary_toggle
-    #       prompt: _(I am experiencing a headache)
-    #       display_prompt: _(I am experiencing a headache:)
-    #       content:
-    #         - label: _(Yes)
-    #           value: "yes"
-    #         - label: _(No)
-    #           value: "no"
-    #       annotation: _(Please be sure to seek medical attention if needed.)
-    #       optional: true
-    #     - name: other_physical_effects
-    #       type: text
-    #       prompt: _(Please note other physical effects you are experiencing)
-    #       display_prompt: _(Other physical effects I experienced:)
-    #       annotation: _(Please be sure to seek medical attention if needed.)
-    #       optional: false
-    #     - name: source  #internally used name for this form element
-    #       type: dropdown  #form type
-    #       prompt: _(Select one of the following to identify the source of the bad air quality.)  #question prompt
-    #       display_prompt: _(Pollution source observed:)  #text used when a submitted report is viewed later
-    #       content:
-    #         - label: _(Asbestos)
-    #           value: absestos
-    #         - label: _(Burning during burn ban)
-    #           value: burning
-    #         - label: _(Chimney smoke)
-    #           value: chimney_smoke
-    #         - label: _(Gas station)
-    #           value: gas_station
-    #         - label: _(Mobile coater)
-    #           value: mobile_coater
-    #         - label: _(Odor)
-    #           value: odor
-    #         - label: _(Outdoor fire)
-    #           value: outdoor_fire
-    #         - label: _(Vehicle pollution)
-    #           value: vehicle_pollution
-    #         - label: _(Visible emission)
-    #           value: visible_emission
-    #         - label: _(Specific business or industry)
-    #           value: business_or_industry
-    #         - label: "_(Don't know/unsure)"
-    #           value: unsure
-    #         - label: _(Other (please describe in comments))
-    #           value: other
-    #       optional: false
-    #     - name: normal_activities
-    #       type: radio_big_buttons
-    #       prompt: "_(Please indicate your agreement with the following statement: My normal activities are affected by the air quality in my neighborhood.)"
-    #       display_prompt: _(My normal activities are affected by the air quality in my neighborhood:)
-    #       content:
-    #         - label: _(Strongly agree)
-    #           value: strongly_agree
-    #         - label: _(Agree)
-    #           value: agree
-    #         - label: _(Neutral)
-    #           value: neutral
-    #         - label: _(Disagree)
-    #           value: disagree
-    #         - label: _(Strongly disagree)
-    #           value: strongly_disagree
-    #       optional: false
-    #     - name: activities_impacted
-    #       type: dropdown
-    #       prompt: _(Select one of the following to indicate how your normal activities are impacted.)
-    #       display_prompt: _(My normal activities were impacted in the following way:)
-    #       content:
-    #         - label: _(I choose to stay indoors to avoid the source of pollution)
-    #           value: stay_indoors
-    #         - label: _(I close the windows, limiting circulation)
-    #           value: close_windows
-    #         - label: _(I open all windows to circulate air)
-    #           value: open_windows
-    #         - label: _(I avoid outdoor physical activities)
-    #           value: avoid_outdoor_activities
-    #         - label: _(I need to constantly clean surfaces, as they are often greasy or dusty)
-    #           value: clean_surfaces
-    #         - label: _(Other (please specify in comments))
-    #           value: other
-    #       optional: false
-    #     - name: additional_comments
-    #       type: text
-    #       prompt: _(Provide any additional comments)
-    #       display_prompt: _(Additional comments:)
-    #       optional: true   
-    # tree:
-    #   name: location_type
-    #   dataset: trees
-    #   datasetSlug: trees
-    #   icon_url: /static/css/images/markers/marker-tree.png
-    #   value: tree
-    #   label: _(Tree)
-    #   fields:
-    #     - name: title
-    #       type: text
-    #       prompt: _(Title)
-    #       display_prompt: _(Title of this tree:)
-    #       placeholder: _(Enter title)
-    #       optional: false
-    #     - name: description
-    #       type: textarea
-    #       prompt: _(Description)
-    #       display_prompt: _(Description of this tree:)
-    #       placeholder: _(Description...)
-    #       optional: false
+    question:
+      includeOnForm: false
+      name: location_type
+      dataset: duwamish
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-question.png
+      value: question
+      label: _(Question)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your question:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your question?)"
+          display_prompt: _(My question:)
+          placeholder: _(Enter question...)
+    idea:
+      includeOnForm: false
+      name: location_type
+      dataset: duwamish
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-idea.png
+      value: idea
+      label: _(Idea)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your idea:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Describe your idea below:)
+          display_prompt: "_(Here's my idea:)"
+          placeholder: _(Description...)
+          optional: false
+    complaint:
+      includeOnForm: false
+      name: location_type
+      dataset: duwamish
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-complaint.png
+      value: complaint
+      label: _(Complaint)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your complaint:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your complaint?)"
+          display_prompt: _(I have the following complaint:)
+          placeholder: _(Description...)
+          optional: false
+    air_watch:  #defines a top-level form category
+      includeOnForm: false
+      name: location_type  #needs to be "location_type"
+      dataset: air
+      datasetSlug: air
+      icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
+      value: air_watch  #internal value used for this category
+      label: _(Air watch)  #label for this category
+      fields:  #field types can be: "dropdown", "radio_big_buttons", "checkbox_big_buttons", "yes_only_big_button", "text", or "textarea"
+        - name: date_time_observed 
+          type: datetime  
+          prompt: _(When did you observe these conditions?)
+          display_prompt: _(I observed these conditions on:)
+          optional: true
+        - name: reside_work_georgetown  
+          type: binary_toggle 
+          prompt: _(Do you reside and/or work in the Georgetown or South Park Neighborhood?)
+          display_prompt: _(I reside or work in Georgetown or South Park:)
+          content:
+            - label: _(Yes)
+              value: "yes"
+            - label: _(No)
+              value: "no"
+          optional: true # NOTE: binary_toggle inputs have no validation
+        - name: odd_smell
+          type: binary_toggle 
+          prompt: _(I observe an odd smell)
+          display_prompt: _(I observed an odd smell:)
+          content:
+            - label: _(Yes)
+              value: "yes"
+            - label: _(No)
+              value: "no"
+          annotation: _(Please be sure to seek medical attention if needed.)
+          optional: true
+        - name: burning
+          type: binary_toggle
+          prompt: _(I have burning or itching eyes/nose/skin)
+          display_prompt: _(I have burning or itching eyes/nose/skin:)
+          content:
+            - label: _(Yes)
+              value: "yes"
+            - label: _(No)
+              value: "no"
+          annotation: _(Please be sure to seek medical attention if needed.)
+          optional: true
+        - name: difficulty_breathing
+          type: binary_toggle
+          prompt: _(I am having difficulty breathing)
+          display_prompt: _(I am having difficulty breathing:)
+          content:
+            - label: _(Yes)
+              value: "yes"
+            - label: _(No)
+              value: "no"
+          annotation: _(Please be sure to seek medical attention if needed.)
+          optional: true
+        - name: headache
+          type: binary_toggle
+          prompt: _(I am experiencing a headache)
+          display_prompt: _(I am experiencing a headache:)
+          content:
+            - label: _(Yes)
+              value: "yes"
+            - label: _(No)
+              value: "no"
+          annotation: _(Please be sure to seek medical attention if needed.)
+          optional: true
+        - name: other_physical_effects
+          type: text
+          prompt: _(Please note other physical effects you are experiencing)
+          display_prompt: _(Other physical effects I experienced:)
+          annotation: _(Please be sure to seek medical attention if needed.)
+          optional: false
+        - name: source  #internally used name for this form element
+          type: dropdown  #form type
+          prompt: _(Select one of the following to identify the source of the bad air quality.)  #question prompt
+          display_prompt: _(Pollution source observed:)  #text used when a submitted report is viewed later
+          content:
+            - label: _(Asbestos)
+              value: absestos
+            - label: _(Burning during burn ban)
+              value: burning
+            - label: _(Chimney smoke)
+              value: chimney_smoke
+            - label: _(Gas station)
+              value: gas_station
+            - label: _(Mobile coater)
+              value: mobile_coater
+            - label: _(Odor)
+              value: odor
+            - label: _(Outdoor fire)
+              value: outdoor_fire
+            - label: _(Vehicle pollution)
+              value: vehicle_pollution
+            - label: _(Visible emission)
+              value: visible_emission
+            - label: _(Specific business or industry)
+              value: business_or_industry
+            - label: "_(Don't know/unsure)"
+              value: unsure
+            - label: _(Other (please describe in comments))
+              value: other
+          optional: false
+        - name: normal_activities
+          type: radio_big_buttons
+          prompt: "_(Please indicate your agreement with the following statement: My normal activities are affected by the air quality in my neighborhood.)"
+          display_prompt: _(My normal activities are affected by the air quality in my neighborhood:)
+          content:
+            - label: _(Strongly agree)
+              value: strongly_agree
+            - label: _(Agree)
+              value: agree
+            - label: _(Neutral)
+              value: neutral
+            - label: _(Disagree)
+              value: disagree
+            - label: _(Strongly disagree)
+              value: strongly_disagree
+          optional: false
+        - name: activities_impacted
+          type: dropdown
+          prompt: _(Select one of the following to indicate how your normal activities are impacted.)
+          display_prompt: _(My normal activities were impacted in the following way:)
+          content:
+            - label: _(I choose to stay indoors to avoid the source of pollution)
+              value: stay_indoors
+            - label: _(I close the windows, limiting circulation)
+              value: close_windows
+            - label: _(I open all windows to circulate air)
+              value: open_windows
+            - label: _(I avoid outdoor physical activities)
+              value: avoid_outdoor_activities
+            - label: _(I need to constantly clean surfaces, as they are often greasy or dusty)
+              value: clean_surfaces
+            - label: _(Other (please specify in comments))
+              value: other
+          optional: false
+        - name: additional_comments
+          type: text
+          prompt: _(Provide any additional comments)
+          display_prompt: _(Additional comments:)
+          optional: true   
+    tree:
+      includeOnForm: true
+      name: location_type
+      dataset: trees
+      datasetSlug: trees
+      icon_url: /static/css/images/markers/marker-tree.png
+      value: tree
+      label: _(Tree)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title)
+          display_prompt: _(Title of this tree:)
+          placeholder: _(Enter title)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Description)
+          display_prompt: _(Description of this tree:)
+          placeholder: _(Description...)
+          optional: false
 
   # define form elements that appear on every form here
   common_form_elements:

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -675,227 +675,227 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
-      name: location_type
-      dataset: duwamish
-      datasetSlug: report
-      icon_url: /static/css/images/markers/marker-question.png
-      value: question
-      label: _(Question)
-      fields:
-        - name: title
-          type: text
-          prompt: _(Title of your question:)
-          display_prompt: _(Title:)
-          placeholder: _(Enter title...)
-          optional: false
-        - name: description
-          type: textarea
-          prompt: "_(What's your question?)"
-          display_prompt: _(My question:)
-          placeholder: _(Enter question...)
-    idea:
-      name: location_type
-      dataset: duwamish
-      datasetSlug: report
-      icon_url: /static/css/images/markers/marker-idea.png
-      value: idea
-      label: _(Idea)
-      fields:
-        - name: title
-          type: text
-          prompt: _(Title of your idea:)
-          placeholder: _(Enter title...)
-          display_prompt: _(Title:)
-          optional: false
-        - name: description
-          type: textarea
-          prompt: _(Describe your idea below:)
-          display_prompt: "_(Here's my idea:)"
-          placeholder: _(Description...)
-          optional: false
-    complaint:
-      name: location_type
-      dataset: duwamish
-      datasetSlug: report
-      icon_url: /static/css/images/markers/marker-complaint.png
-      value: complaint
-      label: _(Complaint)
-      fields:
-        - name: title
-          type: text
-          prompt: _(Title of your complaint:)
-          placeholder: _(Enter title...)
-          display_prompt: _(Title:)
-          optional: false
-        - name: description
-          type: textarea
-          prompt: "_(What's your complaint?)"
-          display_prompt: _(I have the following complaint:)
-          placeholder: _(Description...)
-          optional: false
-    air_watch:  #defines a top-level form category
-      name: location_type  #needs to be "location_type"
-      dataset: air
-      datasetSlug: air
-      icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
-      value: air_watch  #internal value used for this category
-      label: _(Air watch)  #label for this category
-      fields:  #field types can be: "dropdown", "radio_big_buttons", "checkbox_big_buttons", "yes_only_big_button", "text", or "textarea"
-        - name: date_time_observed 
-          type: datetime  
-          prompt: _(When did you observe these conditions?)
-          display_prompt: _(I observed these conditions on:)
-          optional: true
-        - name: reside_work_georgetown  
-          type: binary_toggle 
-          prompt: _(Do you reside and/or work in the Georgetown or South Park Neighborhood?)
-          display_prompt: _(I reside or work in Georgetown or South Park:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          optional: true # NOTE: binary_toggle inputs have no validation
-        - name: odd_smell
-          type: binary_toggle 
-          prompt: _(I observe an odd smell)
-          display_prompt: _(I observed an odd smell:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          annotation: _(Please be sure to seek medical attention if needed.)
-          optional: true
-        - name: burning
-          type: binary_toggle
-          prompt: _(I have burning or itching eyes/nose/skin)
-          display_prompt: _(I have burning or itching eyes/nose/skin:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          annotation: _(Please be sure to seek medical attention if needed.)
-          optional: true
-        - name: difficulty_breathing
-          type: binary_toggle
-          prompt: _(I am having difficulty breathing)
-          display_prompt: _(I am having difficulty breathing:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          annotation: _(Please be sure to seek medical attention if needed.)
-          optional: true
-        - name: headache
-          type: binary_toggle
-          prompt: _(I am experiencing a headache)
-          display_prompt: _(I am experiencing a headache:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          annotation: _(Please be sure to seek medical attention if needed.)
-          optional: true
-        - name: other_physical_effects
-          type: text
-          prompt: _(Please note other physical effects you are experiencing)
-          display_prompt: _(Other physical effects I experienced:)
-          annotation: _(Please be sure to seek medical attention if needed.)
-          optional: false
-        - name: source  #internally used name for this form element
-          type: dropdown  #form type
-          prompt: _(Select one of the following to identify the source of the bad air quality.)  #question prompt
-          display_prompt: _(Pollution source observed:)  #text used when a submitted report is viewed later
-          content:
-            - label: _(Asbestos)
-              value: absestos
-            - label: _(Burning during burn ban)
-              value: burning
-            - label: _(Chimney smoke)
-              value: chimney_smoke
-            - label: _(Gas station)
-              value: gas_station
-            - label: _(Mobile coater)
-              value: mobile_coater
-            - label: _(Odor)
-              value: odor
-            - label: _(Outdoor fire)
-              value: outdoor_fire
-            - label: _(Vehicle pollution)
-              value: vehicle_pollution
-            - label: _(Visible emission)
-              value: visible_emission
-            - label: _(Specific business or industry)
-              value: business_or_industry
-            - label: "_(Don't know/unsure)"
-              value: unsure
-            - label: _(Other (please describe in comments))
-              value: other
-          optional: false
-        - name: normal_activities
-          type: radio_big_buttons
-          prompt: "_(Please indicate your agreement with the following statement: My normal activities are affected by the air quality in my neighborhood.)"
-          display_prompt: _(My normal activities are affected by the air quality in my neighborhood:)
-          content:
-            - label: _(Strongly agree)
-              value: strongly_agree
-            - label: _(Agree)
-              value: agree
-            - label: _(Neutral)
-              value: neutral
-            - label: _(Disagree)
-              value: disagree
-            - label: _(Strongly disagree)
-              value: strongly_disagree
-          optional: false
-        - name: activities_impacted
-          type: dropdown
-          prompt: _(Select one of the following to indicate how your normal activities are impacted.)
-          display_prompt: _(My normal activities were impacted in the following way:)
-          content:
-            - label: _(I choose to stay indoors to avoid the source of pollution)
-              value: stay_indoors
-            - label: _(I close the windows, limiting circulation)
-              value: close_windows
-            - label: _(I open all windows to circulate air)
-              value: open_windows
-            - label: _(I avoid outdoor physical activities)
-              value: avoid_outdoor_activities
-            - label: _(I need to constantly clean surfaces, as they are often greasy or dusty)
-              value: clean_surfaces
-            - label: _(Other (please specify in comments))
-              value: other
-          optional: false
-        - name: additional_comments
-          type: text
-          prompt: _(Provide any additional comments)
-          display_prompt: _(Additional comments:)
-          optional: true   
-    tree:
-      name: location_type
-      dataset: trees
-      datasetSlug: trees
-      icon_url: /static/css/images/markers/marker-tree.png
-      value: tree
-      label: _(Tree)
-      fields:
-        - name: title
-          type: text
-          prompt: _(Title)
-          display_prompt: _(Title of this tree:)
-          placeholder: _(Enter title)
-          optional: false
-        - name: description
-          type: textarea
-          prompt: _(Description)
-          display_prompt: _(Description of this tree:)
-          placeholder: _(Description...)
-          optional: false
+    # question:
+    #   name: location_type
+    #   dataset: duwamish
+    #   datasetSlug: report
+    #   icon_url: /static/css/images/markers/marker-question.png
+    #   value: question
+    #   label: _(Question)
+    #   fields:
+    #     - name: title
+    #       type: text
+    #       prompt: _(Title of your question:)
+    #       display_prompt: _(Title:)
+    #       placeholder: _(Enter title...)
+    #       optional: false
+    #     - name: description
+    #       type: textarea
+    #       prompt: "_(What's your question?)"
+    #       display_prompt: _(My question:)
+    #       placeholder: _(Enter question...)
+    # idea:
+    #   name: location_type
+    #   dataset: duwamish
+    #   datasetSlug: report
+    #   icon_url: /static/css/images/markers/marker-idea.png
+    #   value: idea
+    #   label: _(Idea)
+    #   fields:
+    #     - name: title
+    #       type: text
+    #       prompt: _(Title of your idea:)
+    #       placeholder: _(Enter title...)
+    #       display_prompt: _(Title:)
+    #       optional: false
+    #     - name: description
+    #       type: textarea
+    #       prompt: _(Describe your idea below:)
+    #       display_prompt: "_(Here's my idea:)"
+    #       placeholder: _(Description...)
+    #       optional: false
+    # complaint:
+    #   name: location_type
+    #   dataset: duwamish
+    #   datasetSlug: report
+    #   icon_url: /static/css/images/markers/marker-complaint.png
+    #   value: complaint
+    #   label: _(Complaint)
+    #   fields:
+    #     - name: title
+    #       type: text
+    #       prompt: _(Title of your complaint:)
+    #       placeholder: _(Enter title...)
+    #       display_prompt: _(Title:)
+    #       optional: false
+    #     - name: description
+    #       type: textarea
+    #       prompt: "_(What's your complaint?)"
+    #       display_prompt: _(I have the following complaint:)
+    #       placeholder: _(Description...)
+    #       optional: false
+    # air_watch:  #defines a top-level form category
+    #   name: location_type  #needs to be "location_type"
+    #   dataset: air
+    #   datasetSlug: air
+    #   icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
+    #   value: air_watch  #internal value used for this category
+    #   label: _(Air watch)  #label for this category
+    #   fields:  #field types can be: "dropdown", "radio_big_buttons", "checkbox_big_buttons", "yes_only_big_button", "text", or "textarea"
+    #     - name: date_time_observed 
+    #       type: datetime  
+    #       prompt: _(When did you observe these conditions?)
+    #       display_prompt: _(I observed these conditions on:)
+    #       optional: true
+    #     - name: reside_work_georgetown  
+    #       type: binary_toggle 
+    #       prompt: _(Do you reside and/or work in the Georgetown or South Park Neighborhood?)
+    #       display_prompt: _(I reside or work in Georgetown or South Park:)
+    #       content:
+    #         - label: _(Yes)
+    #           value: "yes"
+    #         - label: _(No)
+    #           value: "no"
+    #       optional: true # NOTE: binary_toggle inputs have no validation
+    #     - name: odd_smell
+    #       type: binary_toggle 
+    #       prompt: _(I observe an odd smell)
+    #       display_prompt: _(I observed an odd smell:)
+    #       content:
+    #         - label: _(Yes)
+    #           value: "yes"
+    #         - label: _(No)
+    #           value: "no"
+    #       annotation: _(Please be sure to seek medical attention if needed.)
+    #       optional: true
+    #     - name: burning
+    #       type: binary_toggle
+    #       prompt: _(I have burning or itching eyes/nose/skin)
+    #       display_prompt: _(I have burning or itching eyes/nose/skin:)
+    #       content:
+    #         - label: _(Yes)
+    #           value: "yes"
+    #         - label: _(No)
+    #           value: "no"
+    #       annotation: _(Please be sure to seek medical attention if needed.)
+    #       optional: true
+    #     - name: difficulty_breathing
+    #       type: binary_toggle
+    #       prompt: _(I am having difficulty breathing)
+    #       display_prompt: _(I am having difficulty breathing:)
+    #       content:
+    #         - label: _(Yes)
+    #           value: "yes"
+    #         - label: _(No)
+    #           value: "no"
+    #       annotation: _(Please be sure to seek medical attention if needed.)
+    #       optional: true
+    #     - name: headache
+    #       type: binary_toggle
+    #       prompt: _(I am experiencing a headache)
+    #       display_prompt: _(I am experiencing a headache:)
+    #       content:
+    #         - label: _(Yes)
+    #           value: "yes"
+    #         - label: _(No)
+    #           value: "no"
+    #       annotation: _(Please be sure to seek medical attention if needed.)
+    #       optional: true
+    #     - name: other_physical_effects
+    #       type: text
+    #       prompt: _(Please note other physical effects you are experiencing)
+    #       display_prompt: _(Other physical effects I experienced:)
+    #       annotation: _(Please be sure to seek medical attention if needed.)
+    #       optional: false
+    #     - name: source  #internally used name for this form element
+    #       type: dropdown  #form type
+    #       prompt: _(Select one of the following to identify the source of the bad air quality.)  #question prompt
+    #       display_prompt: _(Pollution source observed:)  #text used when a submitted report is viewed later
+    #       content:
+    #         - label: _(Asbestos)
+    #           value: absestos
+    #         - label: _(Burning during burn ban)
+    #           value: burning
+    #         - label: _(Chimney smoke)
+    #           value: chimney_smoke
+    #         - label: _(Gas station)
+    #           value: gas_station
+    #         - label: _(Mobile coater)
+    #           value: mobile_coater
+    #         - label: _(Odor)
+    #           value: odor
+    #         - label: _(Outdoor fire)
+    #           value: outdoor_fire
+    #         - label: _(Vehicle pollution)
+    #           value: vehicle_pollution
+    #         - label: _(Visible emission)
+    #           value: visible_emission
+    #         - label: _(Specific business or industry)
+    #           value: business_or_industry
+    #         - label: "_(Don't know/unsure)"
+    #           value: unsure
+    #         - label: _(Other (please describe in comments))
+    #           value: other
+    #       optional: false
+    #     - name: normal_activities
+    #       type: radio_big_buttons
+    #       prompt: "_(Please indicate your agreement with the following statement: My normal activities are affected by the air quality in my neighborhood.)"
+    #       display_prompt: _(My normal activities are affected by the air quality in my neighborhood:)
+    #       content:
+    #         - label: _(Strongly agree)
+    #           value: strongly_agree
+    #         - label: _(Agree)
+    #           value: agree
+    #         - label: _(Neutral)
+    #           value: neutral
+    #         - label: _(Disagree)
+    #           value: disagree
+    #         - label: _(Strongly disagree)
+    #           value: strongly_disagree
+    #       optional: false
+    #     - name: activities_impacted
+    #       type: dropdown
+    #       prompt: _(Select one of the following to indicate how your normal activities are impacted.)
+    #       display_prompt: _(My normal activities were impacted in the following way:)
+    #       content:
+    #         - label: _(I choose to stay indoors to avoid the source of pollution)
+    #           value: stay_indoors
+    #         - label: _(I close the windows, limiting circulation)
+    #           value: close_windows
+    #         - label: _(I open all windows to circulate air)
+    #           value: open_windows
+    #         - label: _(I avoid outdoor physical activities)
+    #           value: avoid_outdoor_activities
+    #         - label: _(I need to constantly clean surfaces, as they are often greasy or dusty)
+    #           value: clean_surfaces
+    #         - label: _(Other (please specify in comments))
+    #           value: other
+    #       optional: false
+    #     - name: additional_comments
+    #       type: text
+    #       prompt: _(Provide any additional comments)
+    #       display_prompt: _(Additional comments:)
+    #       optional: true   
+    # tree:
+    #   name: location_type
+    #   dataset: trees
+    #   datasetSlug: trees
+    #   icon_url: /static/css/images/markers/marker-tree.png
+    #   value: tree
+    #   label: _(Tree)
+    #   fields:
+    #     - name: title
+    #       type: text
+    #       prompt: _(Title)
+    #       display_prompt: _(Title of this tree:)
+    #       placeholder: _(Enter title)
+    #       optional: false
+    #     - name: description
+    #       type: textarea
+    #       prompt: _(Description)
+    #       display_prompt: _(Description of this tree:)
+    #       placeholder: _(Description...)
+    #       optional: false
 
   # define form elements that appear on every form here
   common_form_elements:

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -452,35 +452,35 @@ place_types:
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
-  greenwall:
-    label: _(Green Screen Vote)
-    rules:
-      - condition: '{{layer.focused}} === true'
-        icon:
-          iconUrl: /static/css/images/markers/marker-greenwall.png
-          shadowUrl: /static/css/images/marker-shadow.png
-          iconSize: [50, 60]
-          iconAnchor: [25, 60]
-          shadowSize: [50, 60]
-          shadowAnchor: [14, 60]
+  # greenwall:
+  #   label: _(Green Screen Vote)
+  #   rules:
+  #     - condition: '{{layer.focused}} === true'
+  #       icon:
+  #         iconUrl: /static/css/images/markers/marker-greenwall.png
+  #         shadowUrl: /static/css/images/marker-shadow.png
+  #         iconSize: [50, 60]
+  #         iconAnchor: [25, 60]
+  #         shadowSize: [50, 60]
+  #         shadowAnchor: [14, 60]
 
-      - condition: '{{map.zoom}} < 15'
-        icon:
-          iconUrl: /static/css/images/markers/marker-greenwall.png
-          iconSize: [10, 12]
-          iconAnchor: [5, 12]
+  #     - condition: '{{map.zoom}} < 15'
+  #       icon:
+  #         iconUrl: /static/css/images/markers/marker-greenwall.png
+  #         iconSize: [10, 12]
+  #         iconAnchor: [5, 12]
 
-      - condition: '{{map.zoom}} < 18'
-        icon:
-          iconUrl: /static/css/images/markers/marker-greenwall.png
-          iconSize: [18, 21.75]
-          iconAnchor: [9, 21.75]
+  #     - condition: '{{map.zoom}} < 18'
+  #       icon:
+  #         iconUrl: /static/css/images/markers/marker-greenwall.png
+  #         iconSize: [18, 21.75]
+  #         iconAnchor: [9, 21.75]
 
-      - condition: '{{map.zoom}} >= 18'
-        icon:
-          iconUrl: /static/css/images/markers/marker-greenwall.png
-          iconSize: [38, 46]
-          iconAnchor: [19, 46]
+  #     - condition: '{{map.zoom}} >= 18'
+  #       icon:
+  #         iconUrl: /static/css/images/markers/marker-greenwall.png
+  #         iconSize: [38, 46]
+  #         iconAnchor: [19, 46]
 
   # using temporary icons
   air_watch:

--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -30,12 +30,14 @@
 
     <!-- place buttons for dynamic form categories -->
     <div id="category-btns">
-      {{#each place_config.categories}}
-        <input type="radio" id={{ @key }} class="category-btn clickable">
-        <label for={{ @key }}>
-          <img src={{icon_url}} />
-          <span>{{ label }}</span>
-        </label>
+      {{#each place_config.place_detail}}
+        {{#if this.includeOnForm}}
+          <input type="radio" id={{ @key }} class="category-btn clickable">
+          <label for={{ @key }}>
+            <img src={{icon_url}} />
+            <span>{{ label }}</span>
+          </label>
+        {{/if}}
       {{/each}}
     </div>
     <div style="clear:both"></div>

--- a/src/sa_web/static/js/handlebars-helpers.js
+++ b/src/sa_web/static/js/handlebars-helpers.js
@@ -179,8 +179,8 @@ var Shareabouts = Shareabouts || {};
 
     options = args.slice(-1)[0];
     exclusions = args.slice(0, args.length-1);
-    
-    _.each(NS.Config.place.categories[this.location_type].fields, function(item, i) {
+
+    _.each(NS.Config.place.place_detail[this.location_type].fields, function(item, i) {
       // filter for the correct label/value pair
       var display_value = _.filter(item.content, function(option) {
         return option.value == self[item.name];

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -423,35 +423,6 @@ var Shareabouts = Shareabouts || {};
         this.options.router.navigate('/', {trigger: true});
       }
     },
-    // This gets called for every model that gets added to the place
-    // collection, not just new ones.
-    onAddPlace: function(model) {
-      // If it's new, then show the form in order to edit and save it.
-      if (model.isNew()) {
-
-        this.placeFormView = new S.PlaceFormView({
-          model: model,
-          appView: this,
-          router: this.options.router,
-          defaultPlaceTypeName: this.options.defaultPlaceTypeName,
-          placeTypes: this.options.placeTypes,
-          placeConfig: this.options.placeConfig,
-          userToken: this.options.userToken
-        });
-
-        this.$panel.removeClass().addClass('place-form');
-        this.showPanel(this.placeFormView.render().$el);
-
-//      Init the place form's address search bar
-        this.geocodeAddressPlaceView = (new S.GeocodeAddressPlaceView({
-          el: '#geocode-address-place-bar',
-          router: this.options.router,
-          mapConfig: this.options.mapConfig
-        })).render();
-        this.showNewPin();
-        this.setBodyClass('content-visible', 'place-form-visible');
-      }
-    },
     setBodyClass: function(/* newBodyClasses */) {
       var bodyClasses = ['content-visible', 'place-form-visible'],
           newBodyClasses = Array.prototype.slice.call(arguments, 0),
@@ -559,7 +530,16 @@ var Shareabouts = Shareabouts || {};
       
       this.$panel.removeClass().addClass('place-form');
       this.showPanel(this.placeFormView.render().$el);
+      this.placeFormView.postRender();
+
       this.placeFormView.delegateEvents();
+      // Init the place form's address search bar
+      this.geocodeAddressPlaceView = (new S.GeocodeAddressPlaceView({
+        el: '#geocode-address-place-bar',
+        router: this.options.router,
+        mapConfig: this.options.mapConfig
+      })).render();
+
       this.showNewPin();
       this.setBodyClass('content-visible', 'place-form-visible');
     },

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -30,6 +30,13 @@ var Shareabouts = Shareabouts || {};
     },
     render: function(category, is_category_selected) {
       var selectedCategoryConfig = category && this.options.placeConfig.categories[category] || {};
+      // if there is only one category, skip rendering of category selection buttons
+      if (Object.keys(this.options.placeConfig.categories.length == 1)) {
+        is_category_selected = true;
+        category = Object.keys(this.options.placeConfig.categories)[0];
+        selectedCategoryConfig = this.options.placeConfig.categories[category];
+      }
+
       var data = _.extend({
         place_config: this.options.placeConfig,
         selected_category: selectedCategoryConfig,
@@ -42,6 +49,10 @@ var Shareabouts = Shareabouts || {};
 
       // initialize datetime picker, if relevant
       $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
+
+      if (Object.keys(this.options.placeConfig.categories.length == 1)) {
+        $(".category-btn.clickable + label, #selected-category").css("display", "none");
+      }
 
       return this;
     },

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -37,7 +37,11 @@ var Shareabouts = Shareabouts || {};
       if (placesToIncludeOnForm.length == 1) {
         is_category_selected = true;
         category = placesToIncludeOnForm[0];
+        this.selectedCategory = category;
+        this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset;
+        this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
         selectedCategoryConfig = this.options.placeConfig.place_detail[category];
+        this.collection[this.selectedDatasetId].add({});
       }
 
       var data = _.extend({

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -29,12 +29,15 @@ var Shareabouts = Shareabouts || {};
       }
     },
     render: function(category, is_category_selected) {
-      var selectedCategoryConfig = category && this.options.placeConfig.categories[category] || {};
-      // if there is only one category, skip rendering of category selection buttons
-      if (Object.keys(this.options.placeConfig.categories.length == 1)) {
+      var self = this;
+      var selectedCategoryConfig = category && this.options.placeConfig.place_detail[category] || {};
+      var placesToIncludeOnForm = _.filter(_.keys(self.options.placeConfig.place_detail), function(key) { return self.options.placeConfig.place_detail[key].includeOnForm; });       
+
+      // if there is only one place to include on form, skip category selection page
+      if (placesToIncludeOnForm.length == 1) {
         is_category_selected = true;
-        category = Object.keys(this.options.placeConfig.categories)[0];
-        selectedCategoryConfig = this.options.placeConfig.categories[category];
+        category = placesToIncludeOnForm[0];
+        selectedCategoryConfig = this.options.placeConfig.place_detail[category];
       }
 
       var data = _.extend({
@@ -50,7 +53,8 @@ var Shareabouts = Shareabouts || {};
       // initialize datetime picker, if relevant
       $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
 
-      if (Object.keys(this.options.placeConfig.categories.length == 1)) {
+      // if there is only one place to include on form, hide category selection buttons
+      if (placesToIncludeOnForm.length == 1) {
         $(".category-btn.clickable + label, #selected-category").css("display", "none");
       }
 
@@ -101,8 +105,8 @@ var Shareabouts = Shareabouts || {};
           animationDelay = 400;
 
       this.selectedCategory = $(evt.target).parent().prev().attr('id'),
-      this.selectedDatasetId = this.options.placeConfig.categories[this.selectedCategory].dataset,
-      this.selectedDatasetSlug = this.options.placeConfig.categories[this.selectedCategory].datasetSlug;
+      this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset,
+      this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
 
       // re-render the form with the selected category
       this.render(this.selectedCategory, true);
@@ -157,7 +161,7 @@ var Shareabouts = Shareabouts || {};
       var targetButton = $(evt.target).attr("id"),
           oldValue = $(evt.target).val(),
           // find the match config data for this element
-          altData = _.filter(this.options.placeConfig.categories[this.selectedCategory].fields, function(item) {
+          altData = _.filter(this.options.placeConfig.place_detail[this.selectedCategory].fields, function(item) {
             return item.name == targetButton;
           })[0];
           // fetch alternate label and value

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -19,6 +19,7 @@ var Shareabouts = Shareabouts || {};
       this.priorDatasetId = null;
       this.selectedDatasetSlug = null;
       this.priorModelCid = null;
+      this.singleCategory = false;
       S.TemplateHelpers.overridePlaceTypeConfig(this.options.placeConfig.items,
         this.options.defaultPlaceTypeName);
       S.TemplateHelpers.insertInputTypeFlags(this.options.placeConfig.items);
@@ -36,6 +37,7 @@ var Shareabouts = Shareabouts || {};
       // if there is only one place to include on form, skip category selection page
       if (placesToIncludeOnForm.length == 1) {
         is_category_selected = true;
+        this.singleCategory = true;
         category = placesToIncludeOnForm[0];
         this.selectedCategory = category;
         this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset;
@@ -49,20 +51,20 @@ var Shareabouts = Shareabouts || {};
         selected_category: selectedCategoryConfig,
         is_category_selected: is_category_selected || false,
         user_token: this.options.userToken,
-        current_user: S.currentUser
+        current_user: S.currentUser,
+        is_single_category: (placesToIncludeOnForm.length == 1) ? true : false
       }, S.stickyFieldValues);
 
       this.$el.html(Handlebars.templates['place-form'](data));
 
-      // initialize datetime picker, if relevant
-      $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
-
-      // if there is only one place to include on form, hide category selection buttons
-      if (placesToIncludeOnForm.length == 1) {
-        $(".category-btn.clickable + label, #selected-category").css("display", "none");
-      }
-
       return this;
+    },
+    postRender: function() {
+      // if the form only has a single category, hide category selection buttons
+      if (this.singleCategory) $("#selected-category, #category-btns").addClass("is-visuallyhidden");
+
+      // initialize datetime picker, if relevant
+      $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' }); // <-- add to datetimepicker, or could be a handlebars helper?
     },
     remove: function() {
       this.unbind();

--- a/src/sa_web/static/js/views/place-list-view.js
+++ b/src/sa_web/static/js/views/place-list-view.js
@@ -91,9 +91,11 @@ var Shareabouts = Shareabouts || {};
       $itemViewContainer.empty();
 
       this.collection.each(function(model) {
-        $itemViewContainer.append(self.views[model.cid].$el);
-        // Delegate the events so that the subviews still work
-        self.views[model.cid].supportView.delegateEvents();
+        if (self.views[model.cid]) {
+          $itemViewContainer.append(self.views[model.cid].$el);
+          // Delegate the events so that the subviews still work
+          self.views[model.cid].supportView.delegateEvents();
+        }
       });
     },
     handleSearchInput: function(evt) {


### PR DESCRIPTION
Fixes issue #373 -- should be ready to merge.

This PR changes the dynamic form behavior when only a single form category is active. With only a single category, the form will skip the category selection stage and immediately render the form for the relevant category.

Active category status is controlled via the `includeOnForm` flag (set to either `true` or `false`) under each dynamic form category's section in the config.

This PR adds a `postRender()` method to `place-form-view.js`, which can be used to perform functionality after the view's rendered Handlebars content has been inserted into the DOM.