### PR TITLE
remove reliance on duplicate datasetSlug parameter in dynamic form config

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -621,7 +621,7 @@ activity:
   # Place Types
 
 place:
-  dataset_slug: report # default is 'place'
+  #dataset_slug: report # default is 'place'
   adding_supported: true
   add_button_label: _(Add a report to the map!)
   # Labels for the buttons that toggle the map and list views
@@ -642,7 +642,6 @@ place:
       includeOnForm: false
       name: location_type
       dataset: duwamish
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-observation.png
       value: observation
       label: _(Observation)
@@ -679,7 +678,6 @@ place:
       includeOnForm: false
       name: location_type
       dataset: duwamish
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-question.png
       value: question
       label: _(Question)
@@ -699,7 +697,6 @@ place:
       includeOnForm: false
       name: location_type
       dataset: duwamish
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-idea.png
       value: idea
       label: _(Idea)
@@ -720,7 +717,6 @@ place:
       includeOnForm: false
       name: location_type
       dataset: duwamish
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-complaint.png
       value: complaint
       label: _(Complaint)
@@ -741,7 +737,6 @@ place:
       includeOnForm: false
       name: location_type  #needs to be "location_type"
       dataset: air
-      datasetSlug: air
       icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
       value: air_watch  #internal value used for this category
       label: _(Air watch)  #label for this category
@@ -884,7 +879,6 @@ place:
       includeOnForm: true
       name: location_type
       dataset: trees
-      datasetSlug: trees
       icon_url: /static/css/images/markers/marker-tree.png
       value: tree
       label: _(Tree)

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -621,7 +621,6 @@ activity:
   # Place Types
 
 place:
-  #dataset_slug: report # default is 'place'
   adding_supported: true
   add_button_label: _(Add a report to the map!)
   # Labels for the buttons that toggle the map and list views

--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -33,9 +33,6 @@ var Shareabouts = Shareabouts || {};
       // store separate collection of all places merged together
       this.mergedPlaces = new S.PlaceCollection([]);
 
-      if (!options.placeConfig.dataset_slug) {
-        options.placeConfig.dataset_slug = 'place';
-      }
       S.PlaceModel.prototype.getLoggingDetails = function() {
         return this.id;
       };

--- a/src/sa_web/static/js/views/activity-view.js
+++ b/src/sa_web/static/js/views/activity-view.js
@@ -28,7 +28,7 @@ var Shareabouts = Shareabouts || {};
       // How many pixel from the bottom until we look for more/older actions
       this.infiniteScrollBuffer = this.options.infiniteScrollBuffer || 25;
       // Debounce the scroll handler for efficiency
-      this.debouncedOnScroll = _.debounce(this.onScroll, 600);
+      //this.debouncedOnScroll = _.debounce(this.onScroll, 600);
 
       // Bind click event to an action so that you can see it in a map
       this.$el.delegate('a', 'click', function(evt){
@@ -44,7 +44,9 @@ var Shareabouts = Shareabouts || {};
       });
 
       // Check to see if we're at the bottom of the list and then fetch more results.
-      this.$container.on('scroll', _.bind(this.debouncedOnScroll, this));
+      // NOTE: we've removed the scroll listener for the time being, as it wasn't in
+      // use and has not been refactored for multiple datasets
+      //this.$container.on('scroll', _.bind(this.debouncedOnScroll, this));
 
       // Bind collection events
       _.each(this.activities, function(collection) {
@@ -97,21 +99,25 @@ var Shareabouts = Shareabouts || {};
       }
     },
 
-    onScroll: function(evt) {
-      var self = this,
-          notFetchingDelay = 500,
-          notFetching = function() { self.fetching = false; },
-          shouldFetch = (this.$el.height() - this.$container.height() <=
-                        this.$container.scrollTop() + this.infiniteScrollBuffer);
+    // NOTE: we've removed the scroll listener for the time being, as it wasn't in
+    // use and has not been refactored for multiple datasets
+    // onScroll: function(evt) {
+    //   console.log("onScroll");
 
-      if (shouldFetch && !self.fetching) {
-        self.fetching = true;
-        this.collection.fetchNextPage(
-          function() { _.delay(notFetching, notFetchingDelay); },
-          function() { _.delay(notFetching, notFetchingDelay); }
-        );
-      }
-    },
+    //   var self = this,
+    //       notFetchingDelay = 500,
+    //       notFetching = function() { self.fetching = false; },
+    //       shouldFetch = (this.$el.height() - this.$container.height() <=
+    //                     this.$container.scrollTop() + this.infiniteScrollBuffer);
+
+    //   if (shouldFetch && !self.fetching) {
+    //     self.fetching = true;
+    //     this.collection.fetchNextPage(
+    //       function() { _.delay(notFetching, notFetchingDelay); },
+    //       function() { _.delay(notFetching, notFetchingDelay); }
+    //     );
+    //   }
+    // },
 
     onAddAction: function(model, collection) {
       this.renderAction(model, collection.indexOf(model));

--- a/src/sa_web/static/js/views/activity-view.js
+++ b/src/sa_web/static/js/views/activity-view.js
@@ -59,8 +59,6 @@ var Shareabouts = Shareabouts || {};
       var self = this; 
       options = {
         remove: false,
-        // TODO: fix this usage of the old dataset_slug param...
-        attributesToAdd: { datasetSlug: this.options.placeConfig.dataset_slug },
         attribute: 'target'
       },
       meta = {};
@@ -74,7 +72,7 @@ var Shareabouts = Shareabouts || {};
       options.complete = _.bind(function() {
         // The total length may have changed, so don't overwrite it!
         _.each(self.activities, function(collection, key) {
-          meta[key].length = collection.metadata.length
+          meta[key].length = collection.metadata.length;
           collection.metadata = meta;
           self.fetching = false;
         })
@@ -90,7 +88,9 @@ var Shareabouts = Shareabouts || {};
       // Don't fetch new activity if we're in the middle of fetching a new page.
       if (!this.fetching) {
         this.fetching = true;
-        _.each(this.activities, function(collection) {
+        _.each(this.activities, function(collection, key) {
+          // add dataset slug paramter
+          options.attributesToAdd = { datasetSlug: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].slug }
           collection.fetch(options);
         });
       } else {

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -70,7 +70,7 @@ var Shareabouts = Shareabouts || {};
             url,
             isLinkToPlace = false;
 
-        _.each(this.options.datasetConfigs, function(dataset) {
+        _.each(self.options.datasetConfigs.places, function(dataset) {
           if (href.indexOf('/' + dataset.slug) === 0) isLinkToPlace = true;
         });
 

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -314,6 +314,7 @@ var Shareabouts = Shareabouts || {};
           attributesToAdd: { datasetSlug: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].slug,
                              datasetId: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].id },
           attribute: 'properties',
+
           // Only do this for the first page...
           pageSuccess: _.once(function(collection, data) {
             pageSize = data.features.length;
@@ -498,6 +499,7 @@ var Shareabouts = Shareabouts || {};
           appView: this,
           router: this.options.router,
           placeConfig: this.options.placeConfig,
+          mapConfig: this.options.mapConfig,
           userToken: this.options.userToken,
           // only need to send place collection, since all data added will be a place of some kind
           collection: this.places

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -149,6 +149,7 @@ var Shareabouts = Shareabouts || {};
           surveyConfig: this.options.surveyConfig,
           supportConfig: this.options.supportConfig,
           placeConfig: this.options.placeConfig,
+          mapConfig: this.options.mapConfig,
           // How often to check for new content
           interval: this.options.activityConfig.interval || 30000
         });

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -67,12 +67,17 @@ var Shareabouts = Shareabouts || {};
       $(document).on('click', 'a[href^="/"]', function(evt) {
         var $link = $(evt.currentTarget),
             href = $link.attr('href'),
-            url;
+            url,
+            isLinkToPlace = false;
+
+        _.each(this.options.datasetConfigs, function(dataset) {
+          if (href.indexOf('/' + dataset.slug) === 0) isLinkToPlace = true;
+        });
 
         // Allow shift+click for new tabs, etc.
         if (($link.attr('rel') === 'internal' ||
              href === '/' ||
-             href.indexOf(self.options.placeConfig.dataset_slug) === 0 ||
+             isLinkToPlace ||
              href.indexOf('/filter') === 0) &&
              !evt.altKey && !evt.ctrlKey && !evt.metaKey && !evt.shiftKey) {
           evt.preventDefault();

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -269,8 +269,8 @@ var Shareabouts = Shareabouts || {};
         collection.fetch({
           reset: true,
           attribute: 'target',
-          attributesToAdd: { datasetId: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].id,
-                             datasetSlug: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].slug }
+          attributesToAdd: { datasetId: _.find(self.options.mapConfig.layers, function(layer) { return layer.id == key }).id,
+                             datasetSlug: _.find(self.options.mapConfig.layers, function(layer) { return layer.id == key }).slug }
         });
       });
     },
@@ -317,8 +317,8 @@ var Shareabouts = Shareabouts || {};
           validate: true,
           data: placeParams,
           // get the dataset slug and id from the array of map layers
-          attributesToAdd: { datasetSlug: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].slug,
-                             datasetId: _.filter(self.options.mapConfig.layers, function(layer) { return layer.id == key })[0].id },
+          attributesToAdd: { datasetSlug: _.find(self.options.mapConfig.layers, function(layer) { return layer.id == key }).slug,
+                             datasetId: _.find(self.options.mapConfig.layers, function(layer) { return layer.id == key }).id },
           attribute: 'properties',
 
           // Only do this for the first page...
@@ -462,8 +462,8 @@ var Shareabouts = Shareabouts || {};
           placeConfig: this.options.placeConfig,
           placeTypes: this.options.placeTypes,
           userToken: this.options.userToken,
-          url: _.filter(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug })[0].url,
-          datasetId: _.filter(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug })[0].id
+          url: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).url,
+          datasetId: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).id
         });
         this.placeDetailViews[model.cid] = placeDetailView;
       }
@@ -656,7 +656,7 @@ var Shareabouts = Shareabouts || {};
           includeSubmissions = S.Config.flavor.app.list_enabled !== false,
           layout = S.Util.getPageLayout(),
           // get the dataset id from the map layers array for the given datasetSlug
-          datasetId = _.filter(self.options.mapConfig.layers, function(layer) { return layer.slug == datasetSlug })[0].id,
+          datasetId = _.find(self.options.mapConfig.layers, function(layer) { return layer.slug == datasetSlug }).id,
           onPlaceFound, onPlaceNotFound, modelId;
 
       onPlaceFound = function(model) {

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -111,7 +111,7 @@ var Shareabouts = Shareabouts || {};
           animationDelay = 400;
 
       this.selectedCategory = $(evt.target).parent().prev().attr('id'),
-      this.selectedDatasetId = this.options.placeConfig.categories[this.selectedCategory].dataset,
+      this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset,
       this.selectedDatasetSlug = _.filter(this.options.mapConfig.layers, function(layer) { return self.selectedDatasetId == layer.id })[0].slug
 
       // re-render the form with the selected category

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -111,8 +111,8 @@ var Shareabouts = Shareabouts || {};
           animationDelay = 400;
 
       this.selectedCategory = $(evt.target).parent().prev().attr('id'),
-      this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset,
-      this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
+      this.selectedDatasetId = this.options.placeConfig.categories[this.selectedCategory].dataset,
+      this.selectedDatasetSlug = _.filter(this.options.mapConfig.layers, function(layer) { return self.selectedDatasetId == layer.id })[0].slug
 
       // re-render the form with the selected category
       this.render(this.selectedCategory, true);


### PR DESCRIPTION

**UPDATE** -- this should be ready to merge.
----

This PR fixes issue #372 -- but is not quite ready to merge (see comment below).

This PR removes a confusing duplication of the `datasetSlug` parameter in the dynamic form section of the config. Previously, individual dynamic form categories needed to declare the dataset they write to as well as the dataset slug used in urls. Now, the slug is declared in a single place (in the `map.layers` section).