### PR TITLE
Make change to sidebar on tablets and phones

### DIFF
--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -2773,3 +2773,70 @@ a.close-unsupported-overlay {
     background-size: contain;
   }
 }
+/* Added temporarily for sidebar*/
+@media only screen and (max-width: 960px) {
+  .sidebar.collapsed {
+    width: 100%;
+    box-sizing: border-box;
+    position: absolute;
+    bottom: 0;
+    height: 33px;
+    top: initial;
+  }
+
+  .sidebar {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    overflow: hidden;
+    border-radius: 0px;
+    border: none;
+    z-index: 2000;
+    box-sizing: border-box;
+    box-shadow: none;
+  }
+
+  .sidebar-left .sidebar-tabs {
+    bottom: 0px;
+    position: absolute;
+    height: 33px;
+    z-index: 99;
+    padding: 0 9px;
+    box-sizing: border-box;
+    box-shadow: 0px 0px 3px 1px rgba(0, 0, 0, 0.2);
+  }
+
+  .sidebar-tabs, .sidebar-tabs > ul {
+    width: 100%;
+    display: flex;
+  }
+
+  .sidebar-tabs li {
+    border-radius: 3px;
+  }
+
+  .sidebar-content {
+    padding-bottom: 33px;
+    left: 0 !important;
+    height: auto;
+  }
+
+  .sidebar-header .sidebar-close i {
+    padding: 5px 8px 6px 8px;
+  }
+
+  .sidebar-header .sidebar-close i::before {
+    content: "\f00d";
+  }
+
+  .sidebar-tabs .active {
+    border-radius: 3px;
+  }
+
+  /* Report button*/
+  #add-place-btn-container {
+    border-bottom: none;
+    box-shadow: none;
+  }
+}

--- a/src/sa_web/static/libs/leaflet.sidebar.js
+++ b/src/sa_web/static/libs/leaflet.sidebar.js
@@ -156,6 +156,12 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
             if (L.DomUtil.hasClass(child, 'active'))
                 L.DomUtil.removeClass(child, 'active');
         }
+        for (i = this._panes.length - 1; i >= 0; i--) {
+            var child = this._panes[i];
+            if (L.DomUtil.hasClass(child, 'active')) {
+                L.DomUtil.removeClass(child, 'active');
+            }
+        }
 
         // close sidebar
         if (!L.DomUtil.hasClass(this._sidebar, 'collapsed')) {

--- a/src/sa_web/static/scss/_media.scss
+++ b/src/sa_web/static/scss/_media.scss
@@ -623,3 +623,69 @@
         background-size: contain;
     }
 }
+
+
+/* Added temporarily for sidebar*/
+@media only screen and (max-width: 960px) {
+
+    .sidebar.collapsed {
+        width: 100%;
+        box-sizing: border-box;
+        position: absolute;
+        bottom: 0;
+        height: 33px;
+        top: initial;
+    }
+
+    .sidebar {
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        overflow: hidden;
+        border-radius: 0px;
+        border: none;
+        z-index: 2000;
+        box-sizing: border-box;
+        box-shadow: none;
+    }
+
+    .sidebar-left .sidebar-tabs {
+        bottom: 0px;
+        position: absolute;
+        height: 33px;
+        z-index: 99;
+        padding: 0 9px;
+        box-sizing: border-box;
+        box-shadow: 0px 0px 3px 1px rgba(0,0,0,.2);
+    }
+    .sidebar-tabs, .sidebar-tabs > ul {
+        width: 100%;
+        display: flex;
+    }
+    .sidebar-tabs li {
+        border-radius: 3px;
+    }
+    .sidebar-content {
+        padding-bottom: 33px;
+        left: 0 !important;
+        height: auto;
+    }
+    .sidebar-header .sidebar-close i {
+        padding: 5px 8px 6px 8px;
+    }
+    .sidebar-header .sidebar-close i::before {
+        content: "\f00d";
+    }
+    .sidebar-tabs .active {
+        border-radius: 3px;
+    }
+
+    /* Report button*/
+    #add-place-btn-container {
+        border-bottom: none;
+        box-shadow: none;
+    }
+}
+
+


### PR DESCRIPTION
- Change leaflet-sidebar.js to remove 'active' class from pane when closed
- Move the sidebar to the bottom when window width is below 960px
- Style the sidebar to have a better look
- Change pane close button to 'X' instead of chevron-left when on mobile.