### PR TITLE
Bug fix in goldpbear/duplicateDatasetSlugParam

### DIFF
--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -41,7 +41,8 @@ var Shareabouts = Shareabouts || {};
         category = placesToIncludeOnForm[0];
         this.selectedCategory = category;
         this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset;
-        this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
+        this.selectedDatasetSlug = _.find(this.options.mapConfig.layers, function(layer) { return self.selectedDatasetId == layer.id }).slug;
+        //this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
         selectedCategoryConfig = this.options.placeConfig.place_detail[category];
         this.collection[this.selectedDatasetId].add({});
       }

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -42,7 +42,6 @@ var Shareabouts = Shareabouts || {};
         this.selectedCategory = category;
         this.selectedDatasetId = this.options.placeConfig.place_detail[this.selectedCategory].dataset;
         this.selectedDatasetSlug = _.find(this.options.mapConfig.layers, function(layer) { return self.selectedDatasetId == layer.id }).slug;
-        //this.selectedDatasetSlug = this.options.placeConfig.place_detail[this.selectedCategory].datasetSlug;
         selectedCategoryConfig = this.options.placeConfig.place_detail[category];
         this.collection[this.selectedDatasetId].add({});
       }


### PR DESCRIPTION
I discovered a bug that generates an `undefined` dataset slug when using the dynamic form with only a single category. This PR fixes it.