### PR TITLE
Goldpbear/dynamic form for flavors

### DIFF
--- a/src/flavors/duwamish-watershed/config.yml
+++ b/src/flavors/duwamish-watershed/config.yml
@@ -66,6 +66,18 @@ map:
       type: cartodb
 
   # Legend Layers
+    - id: duwamish
+      type: place
+      slug: report
+
+    - id: trees
+      type: place
+      slug: trees
+
+    - id: air
+      type: place
+      slug: air
+
     - id: restoration
       url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
       sources:
@@ -330,6 +342,43 @@ place_types:
           iconSize: [38, 46]
           iconAnchor: [19, 46]
 
+  air_watch:
+    label: _(Air Watch)
+    rules:
+      - condition: '{{layer.focused}} === true'
+        icon:
+          iconUrl: /static/css/images/markers/marker-greenwall.png
+          shadowUrl: /static/css/images/marker-shadow.png
+          iconSize: [50, 60]
+          iconAnchor: [25, 60]
+          shadowSize: [50, 60]
+          shadowAnchor: [14, 60]
+
+      - condition: '{{map.zoom}} < 11'
+        icon:
+          iconUrl: /static/css/images/markers/marker-greenwall.png
+          iconSize: [10, 12]
+          iconAnchor: [5, 12]
+
+      - condition: '{{map.zoom}} < 17'
+        icon:
+          iconUrl: /static/css/images/markers/marker-greenwall.png
+          iconSize: [18, 21.75]
+          iconAnchor: [9, 21.75]
+
+      - condition: '{{map.zoom}} >= 17'
+        icon:
+          iconUrl: /static/css/images/markers/marker-greenwall.png
+          iconSize: [38, 46]
+          iconAnchor: [19, 46]
+
+  tree:
+    zoomType: mapboxZoomStyle
+    rules:
+      - condition: 'true'
+        icon:
+          iconUrl: /static/css/images/markers/marker-tree.png 
+
 # Sidebar and activity stream should be enabled and disabled together!
 # note: sidebar is aka 'MasterLegend'
 # TODO: Couple the sidebar and activity stream because the activity stream is a component of the sidebar
@@ -411,6 +460,16 @@ sidebar:
             - id: restoration
               title: _(Restoration Sites)
               description: _(Habitat restoration and other improvements)
+              visibleDefault: true
+
+            - id: air
+              title: _(Air Watch Reports)
+              description: _(Air quality reports)
+              visibleDefault: true
+
+            - id: trees
+              title: _(Trees)
+              description: _(New trees)
               visibleDefault: true
 
         - id: grp-history
@@ -519,6 +578,12 @@ place:
   submit_button_label: _(Put it on the map!)
 
   location_item_name: location
+
+  categories:
+    tree:
+      name: location_type
+    air_watch:
+      name: location_type
 
   items:
     - prompt: _(Type of report)

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -68,6 +68,10 @@ map:
       type: cartodb
       opacity: 0.4
 
+    - id: lakewashington
+      type: place
+      slug: report
+
 # The keys show up in the dropdown list when you are adding a new place
 # The values map the place type to map icons (defined below).
 place_types:
@@ -313,6 +317,119 @@ place:
   submit_button_label: _(Submit)
 
   location_item_name: location
+
+  #### begin dynamic form config ####
+  categories:
+    observation:
+      name: location_type
+      dataset: lakewashington
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-observation.png
+      value: observation
+      label: _(Observation)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Description of this observation:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    question:
+      name: location_type
+      dataset: lakewashington
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-question.png
+      value: question
+      label: _(Question)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your question:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your question?)"
+          display_prompt: _(My question:)
+          placeholder: _(Enter question...)
+    idea:
+      name: location_type
+      dataset: lakewashington
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-idea.png
+      value: idea
+      label: _(Idea)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your idea:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Describe your idea below:)
+          display_prompt: "_(Here's my idea:)"
+          placeholder: _(Description...)
+          optional: false
+    complaint:
+      name: location_type
+      dataset: lakewashington
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-complaint.png
+      value: complaint
+      label: _(Complaint)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your complaint:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your complaint?)"
+          display_prompt: _(I have the following complaint:)
+          placeholder: _(Description...)
+          optional: false
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: submitter_name
+      type: text
+      prompt: _(Your name)
+      placeholder: _(Name)
+      optional: true
+    - name: private-submitter_email
+      type: text
+      prompt: _(Your Email)
+      optional: true
+      sticky: true
+      attrs:
+        - key: placeholder
+          value: _(Receive email updates on your report)
+        - key: size
+          value: 30
+    - name: my_image
+      type: file
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
+      optional: true
+      attrs:
+        - key: accept
+          value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
+
 
   items:
     - prompt: _(Type of report)

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -319,11 +319,11 @@ place:
   location_item_name: location
 
   #### begin dynamic form config ####
-  categories:
+  place_detail:
     observation:
+      includeOnForm: true
       name: location_type
       dataset: lakewashington
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-observation.png
       value: observation
       label: _(Observation)
@@ -341,9 +341,9 @@ place:
           placeholder: _(Enter description...)
           optional: false
     question:
+      includeOnForm: true
       name: location_type
       dataset: lakewashington
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-question.png
       value: question
       label: _(Question)
@@ -360,9 +360,9 @@ place:
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
     idea:
+      includeOnForm: true
       name: location_type
       dataset: lakewashington
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-idea.png
       value: idea
       label: _(Idea)
@@ -380,9 +380,9 @@ place:
           placeholder: _(Description...)
           optional: false
     complaint:
+      includeOnForm: true
       name: location_type
       dataset: lakewashington
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-complaint.png
       value: complaint
       label: _(Complaint)

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -47,6 +47,10 @@ map:
       visible: true
       attribution: '&copy; OpenStreetMap contributors, CC-BY-SA. <a href="//mapbox.com/about/maps" target="_blank">Terms &amp; Feedback</a>. Geocoding Courtesy of <a href="//www.mapquest.com/" target="_blank">MapQuest</a> <img src="//developer.mapquest.com/content/osm/mq_logo.png">.'
 
+    # raingardens
+    - id: raingardens
+      type: place
+      slug: report
 
   # Map Layers
 
@@ -178,119 +182,109 @@ place:
 
   location_item_name: Address
 
-  items:
-    - prompt: _(Rain garden location)
-      type: geocoding
-      name: private-rain_garden_address
-      attrs:
-        - key: placeholder
-          value: _(Please type full address, (will not be published))
-        - key: size
-          value: 30
-    - prompt: _(Garden Name)
-      label: _(Garden Name:)
-      type: text
-      name: rain_garden_name
-      optional: true
-      attrs:
-        - key: placeholder
-          value: _(Garden Name)
-        - key: size
-          value: 30
-    - prompt: _(Rain garden size (square feet))
-      label: _(Rain garden size (square feet):)
-      type: text
-      name: rain_garden_size
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Approximate square footage?)
-        - key: size
-          value: 30
-    - prompt: _(Size of contributing area)
-      label: _(Size of contributing area:)
-      type: text
-      name: contributing_area
-      optional: 
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(How large is the catchment area that drains to this rain garden?)
-        - key: size
-          value: 30
-    - prompt: _(Description)
-      label: _(Description:)
-      type: textarea
-      name: description
-      optional: true
-      attrs:
-        - key: placeholder
-          value: _(Any notes you want to add for others would be wonderful :))
-    - name: location_type
-      type: hidden
-      value: raingarden
-    - prompt: _(Primary sources)
-      label: _(Sources:)
-      type: checkbox-list
-      name: sources
-      attrs:
-        - label: _(Roof)
-          value: roof
-        - label: _(Pavement)
-          value: pavement
-        - label: _(Other)
-          value: other
-    - prompt: _(Designer)
-      label: _(Designer:)
-      type: text
-      name: designer
-      optional: 
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Designed by?)
-        - key: size
-          value: 30
-    - prompt: _(Installer)
-      label: _(Installer:)
-      type: text
-      name: installer
-      optional: 
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Installed by?)
-        - key: size
-          value: 30
-    - prompt: _(Contributor's name)
-      label: _(Contributor's name:)
-      type: text
-      name: contributor_name
-      optional: 
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Who should we give credit to?)
-        - key: size
-          value: 30
-    - prompt: _(Your Email)
-      type: text
-      name: private-contributor_email
-      optional: 
-      sticky: true
-      attrs:
-        - key: required
-          value: _(Your email address is kept private and will not be published)
-        - key: size
-          value: 30
-    - prompt:
-      inputfile_label: _(Please add an image)
+  #### begin dynamic form config ####
+  place_detail:
+    raingarden:
+      includeOnForm: true
+      name: location_type
+      dataset: raingardens
+      icon_url: /static/css/images/markers/marker-idea-trans.png
+      value: raingardens
+      label: _(Rain Garden)
+      fields:
+        - name: private-rain_garden_address
+          type: geocoding
+          prompt: _(Rain garden location)
+          placeholder: _(Please type full address, (will not be published))
+          size: 30
+          optional: false
+        - name: rain_garden_name
+          type: text
+          prompt: _(Garden Name)
+          display_prompt: _(Garden Name:)
+          placeholder: _(Garden Name)
+          size: 30
+          optional: true
+        - name: rain_garden_size
+          type: text
+          prompt: _(Rain garden size (square feet))
+          display_prompt: _(Rain garden size (square feet):)
+          placeholder: _(Approximate square footage?)
+          size: 30
+          optional: false
+          sticky: true
+        - name: contributing_area
+          type: text
+          prompt: _(Size of contributing area)
+          display_prompt: _(Size of contributing area:)
+          placeholder: _(How large is the catchment area that drains to this rain garden?)
+          size: 30
+          optional: true
+          sticky: true
+        - name: description
+          type: textarea
+          prompt: _(Description)
+          display_prompt: _(Description:)
+          placeholder: _(Any notes you want to add for others would be wonderful :))
+          optional: true
+        - name: sources
+          type: checkbox_big_buttons
+          prompt: _(Primary sources)
+          display_prompt: _(Sources:)
+          content:
+            - label: _(Roof)
+              value: roof
+            - label: _(Pavement)
+              value: pavement
+            - label: _(Other)
+              value: other
+        - name: designer
+          type: text
+          prompt: _(Designer)
+          display_prompt: _(Designer:)
+          placeholder: _(Designed by?)
+          size: 30
+          optional: true
+          sticky: true
+        - name: installer
+          type: text
+          prompt: _(Installer)
+          display_prompt: _(Installer:)
+          placeholder: _(Installed by?)
+          size: 30
+          optional: true
+          sticky: true
+        - name: contributor_name
+          type: text
+          prompt: _(Contributor's name)
+          display_prompt: _(Contributor's name:)
+          placeholder: _(Who should we give credit to?)
+          size: 30
+          optional: true 
+          sticky: true
+        - name: private-contributor_email
+          type: text
+          prompt: _(Your Email)
+          placeholder: _(Your email address is kept private and will not be published)
+          size: 30
+          optional: true
+          sticky: true
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: my_image
       type: file
-      name: my_image
-      optional:
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
+      optional: true
       attrs:
         - key: accept
           value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
+
 
 survey:
   submission_type: comments

--- a/src/flavors/raingardens/jstemplates/place-form.html
+++ b/src/flavors/raingardens/jstemplates/place-form.html
@@ -16,115 +16,154 @@
     <input type="hidden" name="user_token" value="{{{ user_token }}}">
 
     <!-- TODO We need user data in the template to know whether a user
-    is already logged in.
-    -->
+         is already logged in.
+       -->
 
-    {{# place_config.items }}
+    <!-- container for selected category -->
+    {{#if is_category_selected}}
+    <div id="selected-category">
+      <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selected_category.name }} value={{ selected_category.value }} checked>
+      <label for="selected-category-palceholder">
+        <img src={{ selected_category.icon_url }} />
+        <span>{{ selected_category.label }}</span>
+      </label>
+      <span class="category-menu-hamburger"></span>
+    </div>
+    {{/if}}
 
-      {{#if is_hidden}}
-        <label for="place-{{ name }}"></label>
-        <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" key="hidden"
-               {{#attrs}}
-               {{ key }}="{{ value }}"
-               {{/attrs}} value="{{value}}">
-        {{^}}
-        <div class="{{ type }}">
-          {{#is_authenticated}}
-            {{^is_submitter_name}}
-              <label for="place-{{ name }}"> {{ prompt }}
-                {{# optional }}
-                  <small>
-                    ({{#_}}optional{{/_}})
-                  </small>
-                {{/ optional }}</label>
-            {{/is_submitter_name}}
-            {{^}}
-            <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}
-            </label>
-          {{/is_authenticated}}
+    <!-- place buttons for dynamic form categories -->
+    <div id="category-btns">
+      {{#each place_config.place_detail}}
+        {{#if this.includeOnForm}}
+          <input type="radio" id={{ @key }} class="category-btn clickable">
+          <label for={{ @key }}>
+            <img src={{icon_url}} />
+            <span>{{ label }}</span>
+          </label>
+        {{/if}}
+      {{/each}}
+    </div>
+    <div style="clear:both"></div>
+    <br>
 
-          {{#if is_geocoding}}
-            <div class="geocoding-enabled">
-              <div id="geocode-address-place-bar" class="clearfix">
-                <p class="error is-hidden"></p>
-                <label class="geocode-address-label" for="geocode-address-field"></label>
-                <div class="geocode-spinner is-hidden"></div>
-                <input name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} type="text" id="geocode-address-field" class="geocode-address-field">
-              </div>
+    <!-- generate content for selected category -->
+    {{#each selected_category.fields}}
+      <div class="{{ type }} form-field">
+        <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+        
+        <!-- begin field type definitions -->
+        {{#is type "geocoding"}}
+          <div class="geocoding-enabled">
+            <div id="geocode-address-place-bar" class="clearfix">
+              <p class="error is-hidden"></p>
+              <label class="geocode-address-label" for="geocode-address-field"></label>
+              <div class="geocode-spinner is-hidden"></div>
+              <input name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} type="text" id="geocode-address-field" class="geocode-address-field">
             </div>
-          {{/if}}
+          </div>
+        {{/is}}
+        
+        {{#is type "datetime"}}
+          <input id="datetimepicker" name="{{ name }}" type="text" {{^optional}}required{{/optional}}>
+        {{/is}}
 
-          {{#if is_checkbox_list}}
-            {{# attrs }}
-              <br>
-              <input id="place-{{ value }}" type="checkbox" name="{{ ../name }}" value="{{ value }}" />
-              <label for="place-{{ value }}">{{ label}} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
-            {{/ attrs }}
-          {{/if}}
+        {{#is type "text"}}
+          <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}>
+        {{/is}}
 
-          {{#if is_input}}
-            {{#is_submitter_name}}
-              {{^is_authenticated}}
-                <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} value="{{get_value ../../../.. name}}">
-                <span class="or-sign-in">{{#_}}Or sign in with <a class="auth-inline twitter-btn" href="/users/login/twitter/">Twitter</a>
-                  <a class="auth-inline facebook-btn" href="/users/login/facebook/">Facebook</a>{{/_}}
-                </span>
-              {{/is_authenticated}}
-              {{^}}
-              <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} value="">
-            {{/is_submitter_name}}
-          {{/if}}
+        {{#is type "textarea"}}
+          <textarea id="place-{{ name }}" name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}></textarea>
+        {{/is}}
 
-          {{#is_textarea}}
-            <textarea id="place-{{ name }}" name="{{ name }}"{{#attrs}} {{ key }}="{{ value }}"{{/attrs}}>{{get_value ../.. name}}</textarea>
-          {{/is_textarea}}
+        {{#is type "radio_big_buttons"}}
+          <div>
+            {{#each content}}
+                <input type="radio" name={{ ../name }} id={{ value }} value={{ value }} class="big-btn" {{^optional}}required{{/optional}}>
+                <label for={{ value }}>{{ label }}</label>
+            {{/each}}
+          </div>
+          <div style="clear:both"></div>
+        {{/is}}
 
-          {{#is_select}}
-            <select id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}}>
-              {{#select_item_value ../.. name}}
-                {{# options }}
-                  {{#if label}}
-                    <option value="{{value}}">{{label}}</option>
-                  {{else}}
-                    <option value="{{.}}">{{.}}</option>
-                  {{/if}}
-                {{/ options }}
-              {{/select_item_value}}
+        {{#is type "checkbox_big_buttons"}}
+          <div>
+            {{#each content}}
+              <input type="checkbox" name={{ ../name }} id={{ value }} value={{ value }} class="big-btn">
+              <label for={{ value }}>{{ label }}</label>
+            {{/each}}
+          </div>
+        {{/is}}
+
+        {{#is type "binary_toggle"}}
+          <div>
+            <input type="checkbox" name={{ name }} id={{ name }} value={{ content.[1].value }} data-input-type="binary_toggle" class="big-btn">
+            <label for={{ name }}>{{ content.[1].label }}</label>
+          </div>
+        {{/is}}
+
+        {{#is type "dropdown"}}
+          <div>
+            <select name={{ ../name }} {{^optional}}required{{/optional}}>
+              <option value="" name="no_response">{{#_}}Select...{{/_}}</option>
+              {{#each content}}
+                  <option value={{value}}>{{label}}</option>
+              {{/each}}
             </select>
-          {{/is_select}}
+          </div>
+          <div style="clear:both"></div>
+        {{/is}}
+        <div style="clear:both"></div>
 
-          {{#is_file}}
-            <!--[if lt IE 10 ]><br>Sorry, your browser isn't compatible with our file upload method.<![endif]-->
-            <!--[if (gt IE 9)|!(IE)]><!-->
-            <span class="fileinput-container btn btn-small{{^is_fileinput_supported}} btn-disabled{{/is_fileinput_supported}}">
-              <span>{{ inputfile_label }}</span>
-              <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}"
-                     {{#attrs}} {{ key }}="{{ value }}"{{/attrs}}
-                     {{^is_fileinput_supported}} disabled{{/is_fileinput_supported}}>
-            </span>
-            <span class="fileinput-name">
-              {{^is_fileinput_supported}}{{#_}}Sorry, your browser doesn't support file uploads.{{/_}}{{/is_fileinput_supported}}
-            </span>
-            <!--<![endif]-->
-          {{/is_file}}
+        <!-- optional post-form field message -->
+        {{#if annotation}}
+          <div class="form-annotation">{{annotation}}</div>
+        {{/if}}
 
-          {{#if help_text }}
-            <div class="help-text place-{{ name }}-help-text">{{ help_text }}</div>
-          {{/if}}
+        <!-- end field type definitions -->
+      </div>
+    {{/each}}
 
-        </div>
-        <div class="form-field"></div>
-      {{/if}}
-    {{/ place_config.items }}
-  </fieldset>
+    <!-- begin fields that are included in every form type by default -->
+    {{#if is_category_selected}}
+      <div id="common-form-elements">
+        {{#each place_config.common_form_elements }}
+          <div class="{{ this.type }} form-field">
+            {{#is name "submitter_name"}}
+              {{#if_not_authenticated}}
+                <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+                <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} value="{{get_value ../../../.. name}}" placeholder="{{placeholder}}">
+                <span class="or-sign-in">{{#_}}Or sign in with <a class="auth-inline twitter-btn" href="/users/login/twitter/">Twitter</a> <a class="auth-inline facebook-btn" href="/users/login/facebook/">Facebook</a>{{/_}}</span>
+              {{/if_not_authenticated}}
+            {{/is}}
 
-  <input name="save-place-btn" id="save-place-btn" type="submit" value="{{ place_config.submit_button_label }}" class="btn btn-primary submit-btn">
+            {{#is name "private-submitter_email"}}
+              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+              <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}">
+            {{/is}}
 
-  {{#is_authenticated}}
-    <p class="signed-in-as"><img src="{{ current_user "avatar_url" }}" class="avatar" /> {{ current_user "name" }}. <a class="" href="/users/logout/">{{#_}}Log Out{{/_}}</a></p>
-    {{^}}
-  {{/is_authenticated}}
+            {{#is type "file"}}
+              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+              <span class="fileinput-container btn btn-small{{#if_fileinput_not_supported}} btn-disabled{{/if_fileinput_not_supported}}">
+                <span>{{ inputfile_label }}</span>
+                <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}"
+                       {{#attrs}} {{ key }}="{{ value }}"{{/attrs}}
+                       {{#if_fileinput_not_supported}} disabled{{/if_fileinput_not_supported}}>
+              </span>
+              <span class="fileinput-name">
+                {{#if_fileinput_not_supported}}Sorry, your browser doesn't support file uploads.{{/if_fileinput_not_supported}}
+              </span>
+            {{/is}}
 
-  <div class="form-spinner"></div>
+            {{#is type "submit"}}
+              <div>
+                <input name="save-place-btn" id="save-place-btn" type="submit" value="{{ label }}" class="btn btn-primary submit-btn">
+              </div>
+            {{/is}}
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+    <!-- end common field types -->
 
+    <div class="form-spinner"></div>
 </form>

--- a/src/flavors/snoqualmie/config.yml
+++ b/src/flavors/snoqualmie/config.yml
@@ -75,6 +75,10 @@ map:
       url: https://smartercleanup.cartodb.com/api/v2/viz/d33eff70-0bee-11e6-97dd-0e787de82d45/viz.json
       type: cartodb
 
+    - id: snoqualmie
+      type: place
+      slug: report
+
 # The keys show up in the dropdown list when you are adding a new place
 
 # The values map the place type to map icons (defined below).
@@ -332,7 +336,6 @@ activity:
   # Place Types
 
 place:
-  dataset_slug: report # default is 'place'
   adding_supported: true
   add_button_label: _(Add a comment to the map)
   # Labels for the buttons that toggle the map and list views
@@ -346,51 +349,98 @@ place:
 
   location_item_name: location
 
-  items:
-    - prompt: _(Type of report)
-      type: select
-      options:
-        - label: _(Observation)
-          value: observation
-        - label: _(Question)
-          value: question
-        - label: _(Idea)
-          value: idea
-        - label: _(Complaint)
-          value: complaint
+  #### begin dynamic form config ####
+  place_detail:
+    observation:
+      includeOnForm: true
       name: location_type
-      attrs:
-        - key: required
-    - prompt: _(Title of report)
+      dataset: snoqualmie
+      icon_url: /static/css/images/markers/marker-observation.png
+      value: observation
+      label: _(Observation)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Description of this observation:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    question:
+      includeOnForm: true
+      name: location_type
+      dataset: snoqualmie
+      icon_url: /static/css/images/markers/marker-question.png
+      value: question
+      label: _(Question)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your question:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your question?)"
+          display_prompt: _(My question:)
+          placeholder: _(Enter question...)
+    idea:
+      includeOnForm: true
+      name: location_type
+      dataset: snoqualmie
+      icon_url: /static/css/images/markers/marker-idea.png
+      value: idea
+      label: _(Idea)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your idea:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Describe your idea below:)
+          display_prompt: "_(Here's my idea:)"
+          placeholder: _(Description...)
+          optional: false
+    complaint:
+      includeOnForm: true
+      name: location_type
+      dataset: snoqualmie
+      icon_url: /static/css/images/markers/marker-complaint.png
+      value: complaint
+      label: _(Complaint)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your complaint:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your complaint?)"
+          display_prompt: _(I have the following complaint:)
+          placeholder: _(Description...)
+          optional: false
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: submitter_name
       type: text
-      name: name
-      optional:
-      attrs:
-        - key: required
-        - key: placeholder
-          value: _(Enter title)
-        - key: size
-          value: 30
-    - prompt: _(Description)
-      type: textarea
-      name: description
+      prompt: _(Your name)
+      placeholder: _(Name)
       optional: true
-      attrs:
-        - key: placeholder
-          value: _(Description...)
-    - prompt: _(Your Name)
+    - name: private-submitter_email
       type: text
-      name: submitter_name
-      optional: true
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Name)
-        - key: size
-          value: 30
-    - prompt: _(Your Email)
-      type: text
-      name: private-submitter_email
+      prompt: _(Your Email)
       optional: true
       sticky: true
       attrs:
@@ -398,14 +448,18 @@ place:
           value: _(Receive email updates on your report)
         - key: size
           value: 30
-    - prompt: _(Image)
-      inputfile_label: _(Add an Image)
+    - name: my_image
       type: file
-      name: my_image
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
       optional: true
       attrs:
         - key: accept
           value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
 
 survey:
   submission_type: comments

--- a/src/flavors/trees/config.yml
+++ b/src/flavors/trees/config.yml
@@ -87,6 +87,11 @@ map:
       url: "https://hdbig.cartodb.com/api/v2/viz/f9350ac8-d677-11e5-980b-0e5db1731f59/viz.json"
       opacity: 0.5
 
+      # Trees
+    - id: trees
+      type: place
+      slug: trees
+
   # Report filters
 
 # The keys show up in the dropdown list when you are adding a new place
@@ -414,87 +419,84 @@ place:
 
   location_item_name: Address
 
-  items:
-    - prompt: _(Tree location)
-      type: geocoding
-      name: private-address
-      attrs:
-        - key: placeholder
-          value: _(Please type full address, (will not be published))
-        - key: size
-          value: 30
-    - prompt: _(Tree Name)
-      label: _(Tree Name:)
-      type: text
-      name: common_name
-      attrs:
-        - key: placeholder
-          value: _(ie "California Wax Myrtle")
-        - key: size
-          value: 30
-    - prompt: _(Latin Name)
-      label: _(Latin Name:)
-      type: text
-      name: latin_name
-      optional: true
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(ie "Myrica Californica")
-        - key: size
-          value: 30
-    - prompt: _(Condition?)
-      label: _(Size of contributing area:)
-      type: text
-      name: contributing_area
-      optional: 
-      sticky: true
-      attrs:
-        - key: placeholder
-          value: _(ie "struggling", "okay", "healthy")
-        - key: size
-          value: 30
-    - prompt: _(First Name (will not be published))
-      # label: _(First Name:)
-      type: text
-      name: private-first_name
-      attrs:
-        - key: placeholder
-          value: _(will not be published)
-    - prompt: _(Last Name (will not be published))
-      type: text
-      name: private-last_name
-      attrs:
-        - key: placeholder
-          value: _(will not be published)
-    - prompt: _(Your Email)
-      type: text
-      name: private-submitter_email
-      optional: 
-      sticky: true
-      attrs:
-        - key: required
-        - key: placeholder
-          value: _(Your email address is kept private and will not be published)
-        - key: size
-          value: 30
-    - prompt: _(ID Tag)
-      type: text
-      name: private-id_tag
-      attrs:
-        - key: placeholder
-          value: _(Leave blank if unknown)
-    - name: location_type
-      type: hidden
+  #### begin dynamic form config ####
+  place_detail:
+    tree:
+      includeOnForm: true
+      name: location_type
+      dataset: trees
+      icon_url: /static/css/images/markers/tree.png
       value: tree
-    - prompt:
-      inputfile_label: _(Please add an image)
+      label: _(Tree)
+      fields:
+        - name: private-address
+          type: geocoding
+          prompt: _(Tree location)
+          display_prompt: _(Tree location:)
+          placeholder: _(Please type full address, (will not be published))
+          size: 30
+          optional: false
+        - name: common_name
+          type: text
+          prompt: _(Tree Name)
+          display_prompt: _(Tree Name:)
+          placeholder: _(ie "California Wax Myrtle")
+          size: 30
+          optional: false
+        - name: latin_name
+          type: text
+          prompt: _(Latin Name)
+          display_prompt: _(Latin Name:)
+          placeholder: _(ie "Myrica Californica")
+          size: 30
+          optional: true
+          sticky: true
+        - name: contributing_area
+          type: text
+          prompt: _(Condition?)
+          display_prompt: _(Size of contributing area:)
+          placeholder: _(ie "struggling", "okay", "healthy")
+          size: 30
+          optional: false
+          sticky: true
+        - name: private-first_name
+          type: text
+          prompt: _(First Name (will not be published))
+          # display_prompt: _(First Name:)
+          placeholder: _(will not be published)
+          optional: true
+        - name: private-last_name
+          type: text
+          prompt: _(Last Name (will not be published))
+          placeholder: _(will not be published)
+          optional: true
+        - name: private-submitter_email
+          type: text
+          prompt: _(Your Email) 
+          placeholder: _(Your email address is kept private and will not be published)
+          size: 30
+          optional: true
+          sticky: true
+        - name: private-id_tag
+          type: text
+          prompt: _(ID Tag)
+          placeholder: _(Leave blank if unknown)
+          optional: true
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: my_image
       type: file
-      name: my_image
-      optional:
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
+      optional: true
       attrs:
         - key: accept
           value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
 
 survey:
   submission_type: comments

--- a/src/flavors/waterfront/config.yml
+++ b/src/flavors/waterfront/config.yml
@@ -84,6 +84,10 @@ map:
       title: _(Original river path)
       visibleDefault: false
 
+    - id: waterfront
+      type: place
+      slug: report
+
 # The keys show up in the dropdown list when you are adding a new place
 # The values map the place type to map icons (defined below).
 place_types:
@@ -319,6 +323,118 @@ place:
   submit_button_label: _(Submit)
 
   location_item_name: location
+
+  #### begin dynamic form config ####
+  categories:
+    observation:
+      name: location_type
+      dataset: waterfront
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-observation.png
+      value: observation
+      label: _(Observation)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Description of this observation:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    question:
+      name: location_type
+      dataset: waterfront
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-question.png
+      value: question
+      label: _(Question)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your question:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your question?)"
+          display_prompt: _(My question:)
+          placeholder: _(Enter question...)
+    idea:
+      name: location_type
+      dataset: waterfront
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-idea.png
+      value: idea
+      label: _(Idea)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your idea:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Describe your idea below:)
+          display_prompt: "_(Here's my idea:)"
+          placeholder: _(Description...)
+          optional: false
+    complaint:
+      name: location_type
+      dataset: waterfront
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-complaint.png
+      value: complaint
+      label: _(Complaint)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your complaint:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your complaint?)"
+          display_prompt: _(I have the following complaint:)
+          placeholder: _(Description...)
+          optional: false
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: submitter_name
+      type: text
+      prompt: _(Your name)
+      placeholder: _(Name)
+      optional: true
+    - name: private-submitter_email
+      type: text
+      prompt: _(Your Email)
+      optional: true
+      sticky: true
+      attrs:
+        - key: placeholder
+          value: _(Receive email updates on your report)
+        - key: size
+          value: 30
+    - name: my_image
+      type: file
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
+      optional: true
+      attrs:
+        - key: accept
+          value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
 
   items:
     - prompt: _(Type of report)

--- a/src/flavors/waterfront/config.yml
+++ b/src/flavors/waterfront/config.yml
@@ -325,11 +325,11 @@ place:
   location_item_name: location
 
   #### begin dynamic form config ####
-  categories:
+  place_detail:
     observation:
+      includeOnForm: true
       name: location_type
       dataset: waterfront
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-observation.png
       value: observation
       label: _(Observation)
@@ -347,9 +347,9 @@ place:
           placeholder: _(Enter description...)
           optional: false
     question:
+      includeOnForm: true
       name: location_type
       dataset: waterfront
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-question.png
       value: question
       label: _(Question)
@@ -366,9 +366,9 @@ place:
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
     idea:
+      includeOnForm: true
       name: location_type
       dataset: waterfront
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-idea.png
       value: idea
       label: _(Idea)
@@ -386,9 +386,9 @@ place:
           placeholder: _(Description...)
           optional: false
     complaint:
+      includeOnForm: true
       name: location_type
       dataset: waterfront
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-complaint.png
       value: complaint
       label: _(Complaint)

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -260,11 +260,11 @@ place:
   location_item_name: location
 
   #### begin dynamic form config ####
-  categories:
+  place_detail:
     observation:
+      includeOnForm: true
       name: location_type
       dataset: willamette
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-observation.png
       value: observation
       label: _(Observation)
@@ -282,9 +282,9 @@ place:
           placeholder: _(Enter description...)
           optional: false
     question:
+      includeOnForm: true
       name: location_type
       dataset: willamette
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-question.png
       value: question
       label: _(Question)
@@ -301,9 +301,9 @@ place:
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
     idea:
+      includeOnForm: true
       name: location_type
       dataset: willamette
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-idea.png
       value: idea
       label: _(Idea)
@@ -321,9 +321,9 @@ place:
           placeholder: _(Description...)
           optional: false
     complaint:
+      includeOnForm: true
       name: location_type
       dataset: willamette
-      datasetSlug: report
       icon_url: /static/css/images/markers/marker-complaint.png
       value: complaint
       label: _(Complaint)

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -52,6 +52,10 @@ map:
       type: cartodb
       url: "https://smartercleanup.cartodb.com/api/v2/viz/4a5b14c0-f1fc-11e5-9698-0e5db1731f59/viz.json"
 
+    - id: willamette
+      type: place
+      slug: report
+
 # The keys show up in the dropdown list when you are adding a new place
 # The values map the place type to map icons (defined below).
 place_types:
@@ -254,6 +258,118 @@ place:
   submit_button_label: _(Submit)
 
   location_item_name: location
+
+  #### begin dynamic form config ####
+  categories:
+    observation:
+      name: location_type
+      dataset: willamette
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-observation.png
+      value: observation
+      label: _(Observation)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your observation:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Description of this observation:)
+          display_prompt: _(Further description:)
+          placeholder: _(Enter description...)
+          optional: false
+    question:
+      name: location_type
+      dataset: willamette
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-question.png
+      value: question
+      label: _(Question)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your question:)
+          display_prompt: _(Title:)
+          placeholder: _(Enter title...)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your question?)"
+          display_prompt: _(My question:)
+          placeholder: _(Enter question...)
+    idea:
+      name: location_type
+      dataset: willamette
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-idea.png
+      value: idea
+      label: _(Idea)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your idea:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: _(Describe your idea below:)
+          display_prompt: "_(Here's my idea:)"
+          placeholder: _(Description...)
+          optional: false
+    complaint:
+      name: location_type
+      dataset: willamette
+      datasetSlug: report
+      icon_url: /static/css/images/markers/marker-complaint.png
+      value: complaint
+      label: _(Complaint)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title of your complaint:)
+          placeholder: _(Enter title...)
+          display_prompt: _(Title:)
+          optional: false
+        - name: description
+          type: textarea
+          prompt: "_(What's your complaint?)"
+          display_prompt: _(I have the following complaint:)
+          placeholder: _(Description...)
+          optional: false
+
+  # define form elements that appear on every form here
+  common_form_elements:
+    - name: submitter_name
+      type: text
+      prompt: _(Your name)
+      placeholder: _(Name)
+      optional: true
+    - name: private-submitter_email
+      type: text
+      prompt: _(Your Email)
+      optional: true
+      sticky: true
+      attrs:
+        - key: placeholder
+          value: _(Receive email updates on your report)
+        - key: size
+          value: 30
+    - name: my_image
+      type: file
+      prompt: _(Image)
+      inputfile_label: _(Add an Image)
+      optional: true
+      attrs:
+        - key: accept
+          value: image/*
+    - type: submit
+      label: _(Put it on the map!)
+
+  #### end dynamic form config ####
 
   items:
     - prompt: _(Type of report)

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -2554,43 +2554,23 @@ a.close-unsupported-overlay {
     width: 40%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2079, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #content {
     left: 60%;
     width: 40%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2082, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .content-visible #map-container {
     width: 60%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2084, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #map-container {
     width: 60%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2086, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .geocoding-bar-enabled #content {
     top: 8.5em;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2088, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   a.close-btn {
     line-height: 2;
     top: 10px;
@@ -2601,18 +2581,10 @@ a.close-unsupported-overlay {
     border-radius: 0.325em 0 0 0.325em;
     box-shadow: -0.325em 0.325em 0 rgba(0, 0, 0, 0.1);
   }
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2098, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   a.close-btn span {
     display: none;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2100, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .unsupported-overlay {
     position: absolute;
     top: 5em;
@@ -2620,27 +2592,15 @@ a.close-unsupported-overlay {
     left: 1em;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2105, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .unsupported-message {
     border-radius: 0 0 0.625em 0.625em;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2107, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   a.close-unsupported-overlay {
     right: auto;
     border-radius: 0.325em;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2110, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #content > article {
     overflow: auto;
     padding: 1em 1em 2em;
@@ -2651,10 +2611,6 @@ a.close-unsupported-overlay {
     box-sizing: border-box;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2119, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar {
     position: absolute;
     top: 4em;
@@ -2666,18 +2622,10 @@ a.close-unsupported-overlay {
     margin-top: 0;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2129, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #geocode-address-bar {
     right: 18em;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2133, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error {
     padding: 0.25em 0.5em;
     position: relative;
@@ -2692,26 +2640,14 @@ a.close-unsupported-overlay {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2146, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error + form {
     margin-bottom: 0;
     margin-right: 15em;
   }
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2149, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error.is-hidden + form {
     margin-right: 0;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2152, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #side-bar {
     position: absolute;
     top: 4em;
@@ -2726,25 +2662,13 @@ a.close-unsupported-overlay {
     background-color: rgba(255, 255, 255, 0.9);
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
   .activity-enabled.content-visible #side-bar {
     display: block;
   }
-=======
-  /* line 2166, ../sass/default.sass */
-  .activity-enabled.content-visible #side-bar {
-    display: block;
-  }
-  /* line 2168, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2172, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #ticker {
     right: 0;
     bottom: 0;
@@ -2754,58 +2678,30 @@ a.close-unsupported-overlay {
     background: none;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2179, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #ticker {
     display: block;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2181, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   ul.recent-points {
     font-size: 0.875em;
     -webkit-transform: translateZ(0px);
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2185, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2189, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #master-legend {
     z-index: 15;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
   .activity-enabled.content-visible #master-legend {
     display: block;
   }
-=======
-  /* line 2192, ../sass/default.sass */
-  .activity-enabled.content-visible #master-legend {
-    display: block;
-  }
-  /* line 2194, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2198, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .list-toggle-nav {
     display: block;
     width: auto;
@@ -2816,18 +2712,10 @@ a.close-unsupported-overlay {
     float: left;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2208, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #list-container.is-exposed {
     display: block;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2220, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #colophon {
     color: #007fbf;
     background: url(images/lightpaperfibers.png);
@@ -2846,72 +2734,40 @@ a.close-unsupported-overlay {
     box-sizing: border-box;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2239, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #powered-by {
     margin-bottom: 0;
   }
 }
 @media only screen and (min-width: 80em) {
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2243, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   #content {
     right: 0;
     left: 60%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2246, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #content {
     left: 60%;
     width: 40%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2249, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .content-visible #map-container {
     width: 60%;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2251, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #map-container {
     width: 60%;
   }
 }
 @media only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2 / 1), only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2256, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .share-twitter a {
     background-image: url(images/twitter-64.png);
     background-size: contain;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2259, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .share-facebook a {
     background-image: url(images/facebook-64.png);
     background-size: contain;
   }
 
-<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
-=======
-  /* line 2262, ../sass/default.sass */
->>>>>>> convert waterfront flavor to use dynamic form
   .locate-me {
     background-image: url(images/locate-me@2x.png);
     background-size: contain;

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -2554,23 +2554,43 @@ a.close-unsupported-overlay {
     width: 40%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2079, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #content {
     left: 60%;
     width: 40%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2082, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .content-visible #map-container {
     width: 60%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2084, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #map-container {
     width: 60%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2086, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .geocoding-bar-enabled #content {
     top: 8.5em;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2088, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   a.close-btn {
     line-height: 2;
     top: 10px;
@@ -2581,10 +2601,18 @@ a.close-unsupported-overlay {
     border-radius: 0.325em 0 0 0.325em;
     box-shadow: -0.325em 0.325em 0 rgba(0, 0, 0, 0.1);
   }
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2098, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   a.close-btn span {
     display: none;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2100, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .unsupported-overlay {
     position: absolute;
     top: 5em;
@@ -2592,15 +2620,27 @@ a.close-unsupported-overlay {
     left: 1em;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2105, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .unsupported-message {
     border-radius: 0 0 0.625em 0.625em;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2107, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   a.close-unsupported-overlay {
     right: auto;
     border-radius: 0.325em;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2110, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #content > article {
     overflow: auto;
     padding: 1em 1em 2em;
@@ -2611,6 +2651,10 @@ a.close-unsupported-overlay {
     box-sizing: border-box;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2119, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar {
     position: absolute;
     top: 4em;
@@ -2622,10 +2666,18 @@ a.close-unsupported-overlay {
     margin-top: 0;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2129, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #geocode-address-bar {
     right: 18em;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2133, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error {
     padding: 0.25em 0.5em;
     position: relative;
@@ -2640,14 +2692,26 @@ a.close-unsupported-overlay {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2146, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error + form {
     margin-bottom: 0;
     margin-right: 15em;
   }
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2149, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #geocode-address-bar .error.is-hidden + form {
     margin-right: 0;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2152, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #side-bar {
     position: absolute;
     top: 4em;
@@ -2662,13 +2726,25 @@ a.close-unsupported-overlay {
     background-color: rgba(255, 255, 255, 0.9);
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
   .activity-enabled.content-visible #side-bar {
     display: block;
   }
+=======
+  /* line 2166, ../sass/default.sass */
+  .activity-enabled.content-visible #side-bar {
+    display: block;
+  }
+  /* line 2168, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2172, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #ticker {
     right: 0;
     bottom: 0;
@@ -2678,30 +2754,58 @@ a.close-unsupported-overlay {
     background: none;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2179, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #ticker {
     display: block;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2181, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   ul.recent-points {
     font-size: 0.875em;
     -webkit-transform: translateZ(0px);
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2185, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2189, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #master-legend {
     z-index: 15;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
   .activity-enabled.content-visible #master-legend {
     display: block;
   }
+=======
+  /* line 2192, ../sass/default.sass */
+  .activity-enabled.content-visible #master-legend {
+    display: block;
+  }
+  /* line 2194, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #map-container {
     right: 0;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2198, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .list-toggle-nav {
     display: block;
     width: auto;
@@ -2712,10 +2816,18 @@ a.close-unsupported-overlay {
     float: left;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2208, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #list-container.is-exposed {
     display: block;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2220, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #colophon {
     color: #007fbf;
     background: url(images/lightpaperfibers.png);
@@ -2734,40 +2846,72 @@ a.close-unsupported-overlay {
     box-sizing: border-box;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2239, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #powered-by {
     margin-bottom: 0;
   }
 }
 @media only screen and (min-width: 80em) {
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2243, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   #content {
     right: 0;
     left: 60%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2246, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled #content {
     left: 60%;
     width: 40%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2249, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .content-visible #map-container {
     width: 60%;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2251, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .activity-enabled.content-visible #map-container {
     width: 60%;
   }
 }
 @media only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2 / 1), only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2) {
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2256, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .share-twitter a {
     background-image: url(images/twitter-64.png);
     background-size: contain;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2259, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .share-facebook a {
     background-image: url(images/facebook-64.png);
     background-size: contain;
   }
 
+<<<<<<< 8b1f551b33dc793c0144e0a95febd8a683a7b549
+=======
+  /* line 2262, ../sass/default.sass */
+>>>>>>> convert waterfront flavor to use dynamic form
   .locate-me {
     background-image: url(images/locate-me@2x.png);
     background-size: contain;


### PR DESCRIPTION
References #374 and #343.

This PR updates all flavors **except** `defaultflavor`, `georgetowngreen`, and `duwamish-watershed` (which doesn't have a form) to support the dynamic form.

We've added a `geocoding` field type to `place-detail-view` in order to support the `trees` and `raingardens` flavors. This field type was committed directly to `develop`.