### PR TITLE
Enforce form category ordering

### DIFF
--- a/src/flavors/bogtobay/config.yml
+++ b/src/flavors/bogtobay/config.yml
@@ -711,7 +711,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    pledge:
+    - category: pledge
       includeOnForm: true
       name: location_type
       dataset: bogtobay
@@ -748,7 +748,7 @@ place:
               value: other
           optional: true 
           # NOTE: checkbox_big_button inputs have no validation
-    action:
+    - category: action
       includeOnForm: true
       name: location_type
       dataset: bogtobay
@@ -785,7 +785,7 @@ place:
               value: other
           optional: true 
           # NOTE: checkbox_big_button inputs have no validation
-    observation:
+    - category: observation
       includeOnForm: true
       name: location_type
       dataset: bogtobay
@@ -822,7 +822,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: bogtobay
@@ -841,7 +841,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: false
       name: location_type
       dataset: bogtobay
@@ -861,7 +861,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: false
       name: location_type
       dataset: bogtobay
@@ -881,7 +881,7 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
-    air_watch:  #defines a top-level form category
+    - category: air_watch  #defines a top-level form category
       includeOnForm: false
       name: location_type  #needs to be "location_type"
       dataset: bogtobay

--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -705,8 +705,8 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
-      includeOnForm: false
+    - category: observation
+      includeOnForm: true
       name: location_type
       dataset: duwamish
       icon_url: /static/css/images/markers/marker-observation.png
@@ -741,8 +741,8 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
-      includeOnForm: false
+    - category: question
+      includeOnForm: true
       name: location_type
       dataset: duwamish
       icon_url: /static/css/images/markers/marker-question.png
@@ -760,8 +760,8 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
-      includeOnForm: false
+    - category: idea
+      includeOnForm: true
       name: location_type
       dataset: duwamish
       icon_url: /static/css/images/markers/marker-idea.png
@@ -780,8 +780,8 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
-      includeOnForm: false
+    - category: complaint
+      includeOnForm: true
       name: location_type
       dataset: duwamish
       icon_url: /static/css/images/markers/marker-complaint.png
@@ -800,8 +800,8 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
-    air_watch:  #defines a top-level form category
-      includeOnForm: false
+    - category: air_watch  #defines a top-level form category
+      includeOnForm: true
       name: location_type  #needs to be "location_type"
       dataset: air
       icon_url: /static/css/images/markers/marker-greenwall.png  #TEMPORARY
@@ -941,8 +941,8 @@ place:
           type: text
           prompt: _(Provide any additional comments)
           display_prompt: _(Additional comments:)
-          optional: true   
-    tree:
+          optional: true 
+    - category: tree
       includeOnForm: true
       name: location_type
       dataset: trees

--- a/src/flavors/greenways/config.yml
+++ b/src/flavors/greenways/config.yml
@@ -727,7 +727,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
+    - category: observation
       includeOnForm: true
       name: location_type
       dataset: duwamish
@@ -764,7 +764,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: duwamish
@@ -783,7 +783,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: true
       name: location_type
       dataset: duwamish
@@ -803,7 +803,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...) 
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: true
       name: location_type
       dataset: duwamish
@@ -823,7 +823,7 @@ place:
           display_prompt: _(I have the following complaint:)
           placeholder: _(Description...)
           optional: false
-    air_watch:  #defines a top-level form category
+    - category: air_watch  #defines a top-level form category
       includeOnForm: true
       name: location_type  #needs to be "location_type"
       dataset: air

--- a/src/flavors/lakewashington/config.yml
+++ b/src/flavors/lakewashington/config.yml
@@ -320,7 +320,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
+    - categoy: observation
       includeOnForm: true
       name: location_type
       dataset: lakewashington
@@ -340,7 +340,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: lakewashington
@@ -359,7 +359,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _( )
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: true
       name: location_type
       dataset: lakewashington
@@ -379,7 +379,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: true
       name: location_type
       dataset: lakewashington

--- a/src/flavors/raingardens/config.yml
+++ b/src/flavors/raingardens/config.yml
@@ -184,7 +184,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    raingarden:
+    - category: raingarden
       includeOnForm: true
       name: location_type
       dataset: raingardens

--- a/src/flavors/snoqualmie/config.yml
+++ b/src/flavors/snoqualmie/config.yml
@@ -351,7 +351,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
+    - category: observation
       includeOnForm: true
       name: location_type
       dataset: snoqualmie
@@ -371,7 +371,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: snoqualmie
@@ -390,7 +390,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: true
       name: location_type
       dataset: snoqualmie
@@ -410,7 +410,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: true
       name: location_type
       dataset: snoqualmie

--- a/src/flavors/trees/config.yml
+++ b/src/flavors/trees/config.yml
@@ -421,7 +421,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    tree:
+    - category: tree
       includeOnForm: true
       name: location_type
       dataset: trees

--- a/src/flavors/waterfront/config.yml
+++ b/src/flavors/waterfront/config.yml
@@ -326,7 +326,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
+    - category: observation
       includeOnForm: true
       name: location_type
       dataset: waterfront
@@ -346,7 +346,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: waterfront
@@ -365,7 +365,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: true
       name: location_type
       dataset: waterfront
@@ -385,7 +385,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: true
       name: location_type
       dataset: waterfront

--- a/src/flavors/willamette/config.yml
+++ b/src/flavors/willamette/config.yml
@@ -297,7 +297,7 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
-    observation:
+    - category: observation
       includeOnForm: true
       name: location_type
       dataset: willamette
@@ -317,7 +317,7 @@ place:
           display_prompt: _(Further description:)
           placeholder: _(Enter description...)
           optional: false
-    question:
+    - category: question
       includeOnForm: true
       name: location_type
       dataset: willamette
@@ -336,7 +336,7 @@ place:
           prompt: "_(What's your question?)"
           display_prompt: _(My question:)
           placeholder: _(Enter question...)
-    idea:
+    - category: idea
       includeOnForm: true
       name: location_type
       dataset: willamette
@@ -356,7 +356,7 @@ place:
           display_prompt: "_(Here's my idea:)"
           placeholder: _(Description...)
           optional: false
-    complaint:
+    - category: complaint
       includeOnForm: true
       name: location_type
       dataset: willamette

--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -1,10 +1,10 @@
-<h4 class="">{{ place_config.title }}</h4>
+<h4 class="">{{ placeConfig.title }}</h4>
 <p class="drag-marker-instructions">
   {{#_}}First drag the map to set your pin's location.{{/_}}
 </p>
 <p class="drag-marker-warning is-visuallyhidden">{{#_}}It looks like you didn't set your location yet. Please drag the map to your location.{{/_}}</p>
 
-<p class="form-field">{{ place_config.help_text }}</p>
+<p class="form-field">{{ placeConfig.help_text }}</p>
 
 <form id="place-form" class="place-form clearfix">
 
@@ -17,23 +17,23 @@
        -->
 
     <!-- container for selected category -->
-    {{#if is_category_selected}}
-    <div id="selected-category">
-      <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selected_category.name }} value={{ selected_category.value }} checked>
-      <label for="selected-category-palceholder">
-        <img src={{ selected_category.icon_url }} />
-        <span>{{ selected_category.label }}</span>
-      </label>
-      <span class="category-menu-hamburger"></span>
-    </div>
+    {{#if isCategorySelected}}
+      <div id="selected-category">
+        <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selectedCategory.name }} value={{ selectedCategory.value }} checked>
+        <label for="selected-category-palceholder">
+          <img src={{ selectedCategory.icon_url }} />
+          <span>{{ selectedCategory.label }}</span>
+        </label>
+        <span class="category-menu-hamburger"></span>
+      </div>
     {{/if}}
 
     <!-- place buttons for dynamic form categories -->
     <div id="category-btns">
-      {{#each place_config.place_detail}}
+      {{#each placeConfig.place_detail}}
         {{#if this.includeOnForm}}
-          <input type="radio" id={{ @key }} class="category-btn clickable">
-          <label for={{ @key }}>
+          <input type="radio" id={{ category }} class="category-btn clickable">
+          <label for={{ category }}>
             <img src={{icon_url}} />
             <span>{{ label }}</span>
           </label>
@@ -44,7 +44,7 @@
     <br>
 
     <!-- generate content for selected category -->
-    {{#each selected_category.fields}}
+    {{#each selectedCategory.fields}}
       <div class="{{ type }} form-field">
         <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
         
@@ -121,9 +121,9 @@
     {{/each}}
 
     <!-- begin fields that are included in every form type by default -->
-    {{#if is_category_selected}}
+    {{#if isCategorySelected}}
       <div id="common-form-elements">
-        {{#each place_config.common_form_elements }}
+        {{#each placeConfig.common_form_elements }}
           <div class="{{ this.type }} form-field">
             {{#is name "submitter_name"}}
               {{#if_not_authenticated}}

--- a/src/sa_web/static/js/handlebars-helpers.js
+++ b/src/sa_web/static/js/handlebars-helpers.js
@@ -175,12 +175,13 @@ var Shareabouts = Shareabouts || {};
     var self = this,
         result = '',
         args = Array.prototype.slice.call(arguments),
-        exclusions, options;
+        exclusions, options,
+        selectedCategoryConfig = _.find(NS.Config.place.place_detail, function(categoryConfig) { return categoryConfig.category === self.location_type; }) || {};
 
     options = args.slice(-1)[0];
     exclusions = args.slice(0, args.length-1);
 
-    _.each(NS.Config.place.place_detail[this.location_type].fields, function(item, i) {
+    _.each(selectedCategoryConfig.fields, function(item, i) {
       // filter for the correct label/value pair
       var display_value = _.filter(item.content, function(option) {
         return option.value == self[item.name];

--- a/src/sa_web/static/js/views/place-list-view.js
+++ b/src/sa_web/static/js/views/place-list-view.js
@@ -205,7 +205,8 @@ var Shareabouts = Shareabouts || {};
         var show = function() { model.trigger('show'); },
             hide = function() { model.trigger('hide'); },
             submitter, 
-            locationType = model.get("location_type");
+            locationType = model.get("location_type"),
+            placeConfig = _.find(S.Config.place.place_detail, function(config) { return config.category === locationType });
 
         // If the model doesn't match one of the filters, hide it.
         for (key in filters) {
@@ -219,8 +220,8 @@ var Shareabouts = Shareabouts || {};
         }
 
         // Check whether the remaining models match the search term
-        for (var i = 0; i < S.Config.place.place_detail[locationType].fields.length; i++) { 
-          key = S.Config.place.place_detail[locationType].fields[i].name;
+        for (var i = 0; i < placeConfig.fields.length; i++) { 
+          key = placeConfig.fields[i].name;
           val = model.get(key);
           if (_.isString(val) && val.toUpperCase().indexOf(term) !== -1) {
             return show();


### PR DESCRIPTION
Fixes #416, including updates to flavor configs to support form category ordering.

The dynamic form config should now be an array of category objects, where the category name is listed under the `category` property. Here is a representative example:

    place_detail:
        - category: tree
           includeOnForm: true
           name: location_type
           dataset: trees
           icon_url: /static/css/images/markers/marker-tree.png
           value: tree
           label: _(Tree)
           fields: ....

This PR also has some minor additional refactors/cleanup of the dynamic form code.