### PR TITLE
Fix page refresh bug

### DIFF
--- a/src/flavors/duwamish_flavor/jstemplates/pages/overview.html
+++ b/src/flavors/duwamish_flavor/jstemplates/pages/overview.html
@@ -3,11 +3,11 @@
 <p>{{#_}}We are a community of residents and stakeholders who are monitoring environmental health issues in Seattle's Duwamish Valley.{{/_}}</p>
 
 <ul>
-<li>{{#_}}Help us out and <a href="/place/new">submit a report</a> on the map!{{/_}}</li>
-<li>{{#_}}Here's a little <a href="/page/background">background</a> on the lower Duwamish superfund site and the cleanup of toxic waste in the river.{{/_}}</li>
+<li>{{#_}}Help us out and <a href="/new" rel="internal">submit a report</a> on the map!{{/_}}</li>
+<li>{{#_}}Here's a little <a href="/page/background" rel="internal">background</a> on the lower Duwamish superfund site and the cleanup of toxic waste in the river.{{/_}}</li>
 </ul>
 
 <p class="btn btn-block btn-large close-btn">{{#_}}Start Mapping!{{/_}}</p>
 <br>
 <br>
-{{#_}}This project made possible by our generous <a href="/page/sponsors">sponsors</a>.{{/_}}
+{{#_}}This project made possible by our generous <a href="/page/sponsors" rel="internal">sponsors</a>.{{/_}}


### PR DESCRIPTION
Fixes #437.

@futuresoup -- It turns out that any link with a `rel="internal"` attribute in the HTML tag will get captured by Backbone's router and will be handled client side. So just add that attribute to any links (places, landmarks, pages, etc.) you'd like the client side router to manage.