### PR TITLE
Add a geolocate button to the place form view

### DIFF
--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -1,7 +1,22 @@
-<h4 class="">{{ placeConfig.title }}</h4>
-<p class="drag-marker-instructions">
-  {{#_}}First drag the map to set your pin's location.{{/_}}
-</p>
+<!-- <h4 class="">{{ placeConfig.title }}</h4> -->
+<div class="drag-marker-instructions">
+  <table>
+    <tr id="drag-marker-content">
+      <td>
+        <div class="btn btn-inline btn-geolocate">
+          <img src="/static/css/images/locate-me.png" />
+          {{#_}}Set my location{{/_}}
+        </div> 
+      </td>
+      <td>
+        <p class="drag-text">{{#_}}Or, drag the map to set your location{{/_}}</p>
+      </td>
+    </tr>
+    <tr id="geolocating-msg" class="is-visuallyhidden">
+      <td>{{#_}}Setting your location...{{/_}}</td>
+    </tr>
+  </table>
+</div>
 <p class="drag-marker-warning is-visuallyhidden">{{#_}}It looks like you didn't set your location yet. Please drag the map to your location.{{/_}}</p>
 
 <p class="form-field">{{ placeConfig.help_text }}</p>

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -9,7 +9,8 @@ var Shareabouts = Shareabouts || {};
       'change input[type="file"]': 'onInputFileChange',
       'click .category-btn.clickable + label': 'onCategoryChange',
       'click .category-menu-hamburger': 'onExpandCategories',
-      'click input[data-input-type="binary_toggle"]': 'onBinaryToggle'
+      'click input[data-input-type="binary_toggle"]': 'onBinaryToggle',
+      'click .btn-geolocate': 'onClickGeolocate'
     },
     initialize: function(){
       var self = this;
@@ -61,6 +62,8 @@ var Shareabouts = Shareabouts || {};
       }, S.stickyFieldValues);
 
       this.$el.html(Handlebars.templates['place-form'](data));
+
+      if (this.center) $(".drag-marker-instructions").addClass("is-visuallyhidden");
 
       return this;
     },
@@ -133,6 +136,25 @@ var Shareabouts = Shareabouts || {};
 
       // instantiate appropriate backbone model
       this.collection[self.formState.selectedDatasetId].add({});
+    },
+    onClickGeolocate: function(evt) {
+      var self = this;
+      evt.preventDefault();
+      var ll = this.options.appView.mapView.map.getBounds().toBBoxString();
+      S.Util.log('USER', 'map', 'geolocate', ll, this.options.appView.mapView.map.getZoom());
+      $("#drag-marker-content").addClass("is-visuallyhidden");
+      $("#geolocating-msg").removeClass("is-visuallyhidden");
+
+      this.options.appView.mapView.map.locate()
+        .on("locationfound", function() { 
+          self.center = self.options.appView.mapView.map.getCenter();
+          $("#spotlight-place-mask").remove();
+          self.render();
+        })
+        .on("locationerror", function() {
+          $("#drag-marker-content").removeClass("is-visuallyhidden");
+          $("#geolocating-msg").addClass("is-visuallyhidden");
+        });
     },
     onInputFileChange: function(evt) {
       var self = this,

--- a/src/sa_web/static/scss/_content.scss
+++ b/src/sa_web/static/scss/_content.scss
@@ -353,3 +353,27 @@ a.auth-inline {
     }
 }
 
+/* place form geolocation and instructions bar */
+.drag-marker-instructions {
+    position: relative;
+    background-color: lightyellow;
+    .btn-geolocate {
+        font-size: 0.85em;
+        width: 140px;
+        padding: 5px; 
+        position: relative;
+        img {
+            position: absolute;
+            left: 2px;
+            top: 6px;
+        }
+    }
+    .drag-text {
+        margin-bottom: 0;
+        padding-left: 15px;
+    }
+    #geolocating-msg {
+        color: #888888;
+    }
+}
+


### PR DESCRIPTION
Addresses one issue of #443.

There is still more work to do on the mobile form submission workflow, but this PR adds a geolocation button to the top of the place form view, alongside the "drag map" instructions.

The button appears on all screen sizes, although we could limit its appearance to certain devices using media queries.