### PR TITLE
Lazy loading layers

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -60,11 +60,12 @@ map:
       attribution: 'Hello World'
       type: basemap
 
-    # For our Shareabouts reports
-    - id: reports
-      type: shareabouts
+    # Carto basemap additions layer
+    - id: additions
+      url: https://smartercleanup.cartodb.com/api/v2/viz/3c0197f8-c7d8-11e5-8232-0ecfd53eb7d3/viz.json
+      type: cartodb
 
-  # Legend Layers
+    # Legend Layers
     - id: restoration
       url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
       type: landmark
@@ -602,8 +603,16 @@ sidebar:
           title: _(Community Data)
           visibleDefault: true
           layers:
-            - id: reports
-              title: _(Community Reports)
+            - id: duwamish
+              title: _(Duwamish Cleanup Reports)
+              visibleDefault: false
+
+            - id: trees
+              title: _(Trees!)
+              visibleDefault: true
+
+            - id: air
+              title: _(Air Watch Reports)
               visibleDefault: true
 
             - id: cleanup

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -760,7 +760,10 @@ var Shareabouts = Shareabouts || {};
 
         // TODO: We need to handle the non-deterministic case when
         // 'self.mapView.layerViews[model.cid]` is undefined
-        layer = self.mapView.layerViews[model.cid].layer;
+        if (self.mapView.layerViews[datasetId] && self.mapView.layerViews[datasetId][model.cid]) {
+          layer = self.mapView.layerViews[datasetId][model.cid].layer;
+        }
+
         placeDetailView = self.getPlaceDetailView(model);
 
         if (layer) {

--- a/src/sa_web/static/js/views/basic-layer-view.js
+++ b/src/sa_web/static/js/views/basic-layer-view.js
@@ -9,7 +9,7 @@ var Shareabouts = Shareabouts || {};
     },
     removeLayer: function() {
       if (this.layer) {
-        this.options.landmarkLayers.removeLayer(this.layer);
+        this.options.layer.removeLayer(this.layer);
       }
     },
     onMarkerClick: function() {
@@ -20,15 +20,10 @@ var Shareabouts = Shareabouts || {};
       if (!this.options.mapView.locationTypeFilter ||
         this.options.mapView.locationTypeFilter.toUpperCase() === this.model.get('location_type').toUpperCase()) {
         if (this.layer) {
-          this.options.landmarkLayers.addLayer(this.layer);
+          this.options.layer.addLayer(this.layer);
         }
       } else {
         this.hide();
-      }
-    },
-    removeLayer: function() {
-      if (this.layer) {
-        this.options.landmarkLayers.removeLayer(this.layer);
       }
     }
   });

--- a/src/sa_web/static/js/views/layer-view.js
+++ b/src/sa_web/static/js/views/layer-view.js
@@ -89,7 +89,7 @@ var Shareabouts = Shareabouts || {};
     },
     removeLayer: function() {
       if (this.layer) {
-        this.options.placeLayers.removeLayer(this.layer);
+        this.options.layer.removeLayer(this.layer);
       }
     },
     render: function() {
@@ -146,7 +146,7 @@ var Shareabouts = Shareabouts || {};
       if (!this.options.mapView.locationTypeFilter ||
         this.options.mapView.locationTypeFilter.toUpperCase() === this.model.get('location_type').toUpperCase()) {
         if (this.layer) {
-          this.options.placeLayers.addLayer(this.layer);
+          this.options.layer.addLayer(this.layer);
         }
       } else {
         this.hide();

--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -19,7 +19,6 @@ var Shareabouts = Shareabouts || {};
 
       this.map = L.map(self.el, self.options.mapConfig.options);
 
-      //this.placeLayers = self.getLayerGroups();
       _.each(self.options.mapConfig.layers, function(config) {
         config.loaded = false;
       });
@@ -37,8 +36,6 @@ var Shareabouts = Shareabouts || {};
       if (self.options.mapConfig.geolocation_enabled) {
         self.initGeolocation();
       }
-
-      //self.map.addLayer(self.placeLayers);
 
       self.map.on('dragend', logUserPan);
       $(self.map.zoomControl._zoomInButton).click(logUserZoom);

--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -20,6 +20,9 @@ var Shareabouts = Shareabouts || {};
       this.map = L.map(self.el, self.options.mapConfig.options);
 
       this.placeLayers = self.getLayerGroups();
+      _.each(self.options.mapConfig.layers, function(config) {
+        config.loaded = false;
+      });
       this.layers = {};
       this.layerViews = {};
 
@@ -27,153 +30,6 @@ var Shareabouts = Shareabouts || {};
       this.places = this.options.places;
       this.landmarks = this.options.landmarks;
 
-
-      // Bind visiblity event for custom layers
-      $(S).on('visibility', function (evt, id, visible, isBasemap) {
-        var layer = self.layers[id];
-        if (isBasemap) {
-          var basemaps = _.find(self.options.sidebarConfig.panels, function(panel) {
-            return "basemaps" in panel;
-          }).basemaps;
-          _.each(basemaps, function(basemap) {
-            if (basemap.id === id) {
-              self.map.addLayer(layer);
-              layer.bringToBack();
-            } else {
-              self.map.removeLayer(self.layers[basemap.id]);
-            }
-          });
-        } else if (layer) {
-          self.setLayerVisibility(layer, visible);
-        } else {
-          // Handles cases when we fire events for layers that are not yet
-          // loaded (ie cartodb layers, which are loaded asynchronously)
-          var mapLayerConfig = _.find(self.options.mapConfig.layers, function(layer) {
-            return layer.id === id;
-          });
-          // We are setting the asynch layer config's default visibility here to
-          // ensure they are added to the map when they are eventually loaded:
-          mapLayerConfig.asyncLayerVisibleDefault = visible;
-        }
-      });
-
-      // Add layers defined in the config file
-      _.each(self.options.mapConfig.layers, function(config) {
-        var layer,
-            collectionId,
-            collection;
-        if (config.type && config.type === 'json') {
-          var url = config.url;
-          if (config.sources) {
-            url += '?';
-            config.sources.forEach(function (source) {
-              url += encodeURIComponent(source) + '&';
-            });
-          }
-          layer = L.argo(url, config);
-          self.layers[config.id] = layer;
-        } else if (config.type && config.type === 'esri-feature') {
-          if (config.loadStrategy === 'all at once') {
-            // IDs can be returned all at once, while actual geometries are
-            // capped at 1000 per request. Gets an array of all IDs then
-            // requests their geometry 1000 at a time.
-            L.esri.Tasks.query({
-              url: config.url
-            }).ids(function(error, ids) {
-              var esriLayers = [];
-
-              for (var i = 0; i < ids.length; i += 1000) {
-                L.esri.Tasks.query({url: config.url})
-                  .featureIds(ids.slice(i, i + 1000))
-                  .run(function(error, geoJson) {
-                    var currentLayer = L.argo(geoJson, config);
-
-                    if (config.popupContent) {
-                      curentLayer.bindPopup(function(feature) {
-                        return L.Argo.t(config.popupContent, feature.properties);
-                      });
-                    }
-
-                    esriLayers.push(currentLayer);
-
-                    if (esriLayers.length === (Math.floor(ids.length / 1000) + 1)) {
-                      // All requests have completed
-                      self.layers[config.id] = L.layerGroup(esriLayers);
-                    }
-                  });
-              }
-            });
-          } else {
-            layer = L.esri.featureLayer(
-              {
-                url: config.url,
-                style: function(feature) {
-                  return L.Argo.getStyleRule(feature, config.rules)['style'];
-                }
-              }
-            );
-
-            if (config.popupContent) {
-              layer.bindPopup(function(feature) {
-                return L.Argo.t(config.popupContent, feature.properties);
-              });
-            }
-
-            self.layers[config.id] = layer;
-          }
-        } else if (config.type && config.type === 'landmark') {
-          collectionId = config.id;
-          self.layers[collectionId] = L.layerGroup();
-          self.layerViews[collectionId] = {};
-
-          // Bind our landmark data events:
-          collection = self.landmarks[collectionId];
-          collection.on('add', self.addLandmarkLayerView(collectionId), self);
-          collection.on('remove', self.removeLandmarkLayerView(collectionId), self);
-        } else if (config.type && config.type === 'cartodb') {
-          cartodb.createLayer(self.map, config.url, { legends: false })
-            .on('done', function(cartoLayer) {
-              self.layers[config.id] = cartoLayer;
-              // This is only set when the 'visibility' event is fired before
-              // our carto layer is loaded:
-              if (config.asyncLayerVisibleDefault) {
-                cartoLayer.addTo(self.map);
-              }
-            })
-            .on('error', function(err) {
-              S.Util.log('Cartodb layer creation error:', err);
-            });
-        } else if (config.type && config.type === 'shareabouts') {
-          self.layers[config.id] = self.placeLayers;
-        } else if (config.layers) {
-          // If "layers" is present, then we assume that the config
-          // references a Leaflet WMS layer.
-          // http://leafletjs.com/reference.html#tilelayer-wms
-          layer = L.tileLayer.wms(config.url, {
-            layers: config.layers,
-            format: config.format,
-            transparent: config.transparent,
-            version: config.version,
-            crs: L.CRS.EPSG3857,
-            // default TileLayer options
-            attribution: config.attribution,
-            opacity: config.opacity,
-            fillColor: config.color,
-            weight: config.weight,
-            fillOpacity: config.fillOpacity
-          });
-          self.layers[config.id] = layer;
-        } else {
-          // Assume a tile layer
-          // TODO: Isn't type=tile for back compatibility
-          layer = L.tileLayer(config.url, config);
-          self.layers[config.id] = layer;
-        }
-
-        if (!self.options.legend_enabled) {
-          $(S).trigger('visibility', [config.id, true, false]);
-        }
-      });
       // Remove default prefix
       self.map.attributionControl.setPrefix('');
 
@@ -209,6 +65,35 @@ var Shareabouts = Shareabouts || {};
         collection.on('reset', self.render, self);
         collection.on('add', self.addLayerView, self);
         collection.on('remove', self.removeLayerView, self);
+      });
+
+      // Bind visiblity event for custom layers
+      $(S).on('visibility', function (evt, id, visible, isBasemap) {
+        var config = _.find(self.options.mapConfig.layers, function(c) {
+          return c.id === id;
+        });
+        var layer = self.layers[id];
+        if (config && !config.loaded && visible) {
+          self.createLayerFromConfig(config);
+          config.loaded = true;
+          layer = self.layers[id];
+        }
+
+        if (layer) {
+          self.setLayerVisibility(layer, visible);
+          if (visible && isBasemap) {
+            layer.bringToBack();
+          }
+        } else {
+          // Handles cases when we fire events for layers that are not yet
+          // loaded (ie cartodb layers, which are loaded asynchronously)
+          var mapLayerConfig = _.find(self.options.mapConfig.layers, function(layer) {
+            return layer.id === id;
+          });
+          // We are setting the asynch layer config's default visibility here to
+          // ensure they are added to the map when they are eventually loaded:
+          mapLayerConfig.asyncLayerVisibleDefault = visible;
+        }
       });
     }, // end initialize
 
@@ -404,6 +289,119 @@ var Shareabouts = Shareabouts || {};
             return L.divIcon({ html: n, className: className, iconSize: [size, size] });
           }
         });
+      }
+    },
+    createLayerFromConfig: function(config) {
+      var self = this,
+          layer,
+          collectionId,
+          collection;
+      if (config.type && config.type === 'json') {
+        var url = config.url;
+        if (config.sources) {
+          url += '?';
+          config.sources.forEach(function (source) {
+            url += encodeURIComponent(source) + '&';
+          });
+        }
+        layer = L.argo(url, config);
+        self.layers[config.id] = layer;
+      } else if (config.type && config.type === 'esri-feature') {
+        if (config.loadStrategy === 'all at once') {
+          // IDs can be returned all at once, while actual geometries are
+          // capped at 1000 per request. Gets an array of all IDs then
+          // requests their geometry 1000 at a time.
+          L.esri.Tasks.query({
+            url: config.url
+          }).ids(function(error, ids) {
+            var esriLayers = [];
+
+            for (var i = 0; i < ids.length; i += 1000) {
+              L.esri.Tasks.query({url: config.url})
+                .featureIds(ids.slice(i, i + 1000))
+                .run(function(error, geoJson) {
+                  var currentLayer = L.argo(geoJson, config);
+
+                  if (config.popupContent) {
+                    curentLayer.bindPopup(function(feature) {
+                      return L.Argo.t(config.popupContent, feature.properties);
+                    });
+                  }
+
+                  esriLayers.push(currentLayer);
+
+                  if (esriLayers.length === (Math.floor(ids.length / 1000) + 1)) {
+                    // All requests have completed
+                    self.layers[config.id] = L.layerGroup(esriLayers);
+                  }
+                });
+            }
+          });
+        } else {
+          layer = L.esri.featureLayer(
+            {
+              url: config.url,
+              style: function(feature) {
+                return L.Argo.getStyleRule(feature, config.rules)['style'];
+              }
+            }
+          );
+
+          if (config.popupContent) {
+            layer.bindPopup(function(feature) {
+              return L.Argo.t(config.popupContent, feature.properties);
+            });
+          }
+
+          self.layers[config.id] = layer;
+        }
+      } else if (config.type && config.type === 'landmark') {
+        collectionId = config.id;
+        self.layers[collectionId] = L.layerGroup();
+        self.layerViews[collectionId] = {};
+
+        // Bind our landmark data events:
+        collection = self.landmarks[collectionId];
+        collection.on('add', self.addLandmarkLayerView(collectionId), self);
+        collection.on('remove', self.removeLandmarkLayerView(collectionId), self);
+      } else if (config.type && config.type === 'cartodb') {
+        cartodb.createLayer(self.map, config.url, { legends: false })
+          .on('done', function(cartoLayer) {
+            self.layers[config.id] = cartoLayer;
+            // This is only set when the 'visibility' event is fired before
+            // our carto layer is loaded:
+            if (config.asyncLayerVisibleDefault) {
+              cartoLayer.addTo(self.map);
+            }
+          })
+          .on('error', function(err) {
+            S.Util.log('Cartodb layer creation error:', err);
+          });
+      } else if (config.type && config.type === 'shareabouts') {
+        self.layers[config.id] = self.placeLayers;
+      } else if (config.layers) {
+        // If "layers" is present, then we assume that the config
+        // references a Leaflet WMS layer.
+        // http://leafletjs.com/reference.html#tilelayer-wms
+        layer = L.tileLayer.wms(config.url, {
+          layers: config.layers,
+          format: config.format,
+          transparent: config.transparent,
+          version: config.version,
+          crs: L.CRS.EPSG3857,
+          // default TileLayer options
+          attribution: config.attribution,
+          opacity: config.opacity,
+          fillColor: config.color,
+          weight: config.weight,
+          fillOpacity: config.fillOpacity
+        });
+        self.layers[config.id] = layer;
+      } else {
+        // Assume a tile layer
+        // TODO: Isn't type=tile for back compatibility
+        layer = L.tileLayer(config.url, config);
+        self.layers[config.id] = layer;
       }
     }
   });


### PR DESCRIPTION
Addresses #436.
Fixes #408.

This will have less of an effect on performance than I originally thought, because I thought that we were just hiding, but still rendering, non-visible layers. We already were lazy-rendering. This PR makes it so that we will only make network requests for a layer once it is made visible. Obviously, this has no effect on layer-types like Carto that load progressively.