### PR TITLE
Control basemaps via story mode

### DIFF
--- a/src/sa_web/static/js/models.js
+++ b/src/sa_web/static/js/models.js
@@ -34,7 +34,8 @@ var Shareabouts = Shareabouts || {};
           previous: story.order[url].previous,
           zoom: story.order[url].zoom,
           panTo: story.order[url].panTo,
-          visibleLayers: story.order[url].visibleLayers
+          visibleLayers: story.order[url].visibleLayers,
+          basemap: story.order[url].basemap
         }
       }
     });

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -123,6 +123,7 @@ var Shareabouts = Shareabouts || {};
       this.mapView = new S.MapView({
         el: '#map',
         mapConfig: this.options.mapConfig,
+        sidebarConfig: S.Config.sidebar,
         places: this.places,
         landmarks: this.landmarks,
         router: this.options.router,
@@ -250,7 +251,8 @@ var Shareabouts = Shareabouts || {};
             "panTo": config.panTo || null,
             "visibleLayers": config.visible_layers || story.default_visible_layers,
             "previous": story.order[(i - 1 + totalStoryElements) % totalStoryElements].url,
-            "next": story.order[(i + 1) % totalStoryElements].url
+            "next": story.order[(i + 1) % totalStoryElements].url,
+            "basemap": config.basemap || null
           }
         });
         story.order = storyStructure;
@@ -561,6 +563,11 @@ var Shareabouts = Shareabouts || {};
     // If a model has a story object, set the appropriate layer
     // visilbilities and update legend checkboxes
     setStoryLayerVisibility: function(model) {
+      // change basemap if requested
+      if (model.attributes.story.basemap) {
+        $(S).trigger('visibility', [model.attributes.story.basemap, true, true]);
+        $("#map-" + model.attributes.story.basemap).prop("checked", true);
+      }
       // set layer visibility based on story config
       _.each(model.attributes.story.visibleLayers, function(targetLayer) {
         $(S).trigger('visibility', [targetLayer, true]);

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -648,9 +648,12 @@ var Shareabouts = Shareabouts || {};
         // Focus the one we're looking
         model.trigger('focus');
 
-        if (model.attributes.story) {
+        if (model.get("story")) {
           self.isStoryActive = true;
           self.setStoryLayerVisibility(model);
+        } else if (self.isStoryActive) {
+          self.isStoryActive = false;
+          self.restoreDefaultLayerVisibility();
         } else {
           self.isStoryActive = false;
         }
@@ -810,9 +813,12 @@ var Shareabouts = Shareabouts || {};
         // Focus the one we're looking
         model.trigger('focus');
 
-        if (model.attributes.story) {
+        if (model.get("story")) {
           self.isStoryActive = true;
           self.setStoryLayerVisibility(model);
+        } else if (self.isStoryActive) {
+          self.isStoryActive = false;
+          self.restoreDefaultLayerVisibility();
         } else {
           self.isStoryActive = false;
         }

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -588,9 +588,11 @@ var Shareabouts = Shareabouts || {};
     },
 
     restoreDefaultLayerVisibility: function() {
-      _.each(this.options.sidebarConfig.panels[0].groupings, function(group) {
-        _.each(group.layers, function(layer) {
-          $(S).trigger('visibility', [layer.id, !!layer.visibleDefault]);
+      var gisLayersPanel = _.find(this.options.sidebarConfig.panels, function(panel) { return panel.id === "gis-layers"; });
+      _.each({"groupings": gisLayersPanel.groupings.layers, "basemaps": gisLayersPanel.basemaps}, function(layers, key) {
+        _.each(layers, function(layer) {
+          if (key === "basemaps" && !layer.visibleDefault) return;
+          $(S).trigger('visibility', [layer.id, !!layer.visibleDefault, (key === "basemaps" ? true : false)]);
           $("#map-" + layer.id).prop("checked", !!layer.visibleDefault);
         });
       });

--- a/src/sa_web/static/js/views/gis-legend-view.js
+++ b/src/sa_web/static/js/views/gis-legend-view.js
@@ -28,12 +28,6 @@ var Shareabouts = Shareabouts || {};
                                return !!basemap.visibleDefault;
                              });
 
-      _.each(this.options.config.basemaps, function(basemap) {
-        if (basemap !== initialBasemap) {
-          $(S).trigger('visibility', [basemap.id, !!basemap.visibleDefault, true]);
-        }
-      });
-
       $(S).trigger('visibility', [initialBasemap.id, !!initialBasemap.visibleDefault, true]);
 
       return this;
@@ -54,12 +48,6 @@ var Shareabouts = Shareabouts || {};
           isChecked = !!radio.is(':checked'),
           basemaps = this.options.config.basemaps;
 
-      for(var i = 0; i < basemaps.length; i++) {
-        var basemap = basemaps[i];
-        if (basemap.id !== id) {
-          $(S).trigger('visibility', [basemap.id, !isChecked, true]);
-        }
-      }
       $(S).trigger('visibility', [id, isChecked, true]);
     },
 

--- a/src/sa_web/static/js/views/map-view.js
+++ b/src/sa_web/static/js/views/map-view.js
@@ -181,12 +181,17 @@ var Shareabouts = Shareabouts || {};
       $(S).on('visibility', function (evt, id, visible, isBasemap) {
         var layer = self.layers[id];
         if (isBasemap) {
-          if (visible) {
-            self.map.addLayer(layer);
-            layer.bringToBack();
-          } else {
-            self.map.removeLayer(layer);
-          }
+          var basemaps = _.find(self.options.sidebarConfig.panels, function(panel) {
+            return "basemaps" in panel;
+          }).basemaps;
+          _.each(basemaps, function(basemap) {
+            if (basemap.id === id) {
+              self.map.addLayer(layer);
+              layer.bringToBack();
+            } else {
+              self.map.removeLayer(self.layers[basemap.id]);
+            }
+          });
         } else if (layer) {
           self.setLayerVisibility(layer, visible);
         } else {


### PR DESCRIPTION
Addresses #422.

This PR adds the ability to manually set the basemap layer via the story section of the config. To set a basemap layer, use the `basemap` flag on a story element. For example:
```
-  url: report/412
   basemap: dark
```
Basemaps set in this way should be listed under the `basemaps` panel in the legend section of the config. ~~and their corresponding layer config should have a `type: basemap` flag set.~~

There is currently no default basemap configuration in story mode, so setting the basemap layer via a story element will keep that basemap layer active until another story element changes it. If a story changes the default basemap, the default basemap will be restored when the user leaves story mode.

Note that this PR refactors a bit of the multi-basemap code introduced in #440. Specifically, it moves code that loops through all basemap layers [here](https://github.com/smartercleanup/platform/blob/develop-0.7.0/src/sa_web/static/js/views/gis-legend-view.js#L31-L35) and [here](https://github.com/smartercleanup/platform/blob/develop-0.7.0/src/sa_web/static/js/views/gis-legend-view.js#L57-L62) to the `visibility` event handler in `map-view.js`. This way, all the looping is contained in a single place and the story mode layer controls don't need to duplicate this code.

@zmbc -- if you have a few minutes, would you mind reviewing the refactor of the code that manages basemap toggling, just to make sure nothing is out of whack?