### PR TITLE
Accommodate landmark data migrations

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -61,11 +61,11 @@ map:
       type: basemap
 
     # Legend Layers
-    - id: restoration
-      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
-      type: landmark
-      sources:
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+    # - id: restoration
+    #   url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
+    #   type: landmark
+    #   sources:
+    #     - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
 
     - id: story-markers
       url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
@@ -77,6 +77,14 @@ map:
       type: place
       slug: report
 
+    - id: vision
+      type: place
+      slug: vision
+
+    - id: restoration
+      type: place
+      slug: restoration
+
     - id: trees
       type: place
       slug: trees
@@ -85,11 +93,11 @@ map:
       type: place
       slug: air
 
-    - id: vision
-      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
-      sources:
-        - "http://a.tiles.mapbox.com/v4/smartercleanup.mfigd1mf/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
-      type: landmark
+    # - id: vision
+    #   url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
+    #   sources:
+    #     - "http://a.tiles.mapbox.com/v4/smartercleanup.mfigd1mf/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+    #   type: landmark
 
        # WRIA9 watershed
     - id: watershed
@@ -223,89 +231,89 @@ place_types:
   wetland:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-land_no-prog-or-dead.png
   park:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-parks_no-prog-or-dead.png
 
   school:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-qual_no-prog-or-dead.png
 
   police:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-safe_no-prog-or-dead.png
 
   rail:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-transp_no-prog-or-dead.png
 
   town-hall:
     zoomType: georgetownZoomStyle
     rules:
-      - condition: '"{{properties.marker-color}}" == "a3e46b"'
+      - condition: '"{{marker-color}}" == "a3e46b"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_comp.png
 
-      - condition: '"{{properties.marker-color}}" == "f1f075"'
+      - condition: '"{{marker-color}}" == "f1f075"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_prog.png
 
-      - condition: '"{{properties.marker-color}}" == "f86767"'
+      - condition: '"{{marker-color}}" == "f86767"'
         icon:
           iconUrl: /static/css/images/markers/marker-hist_no-prog-or-dead.png
 
@@ -632,7 +640,7 @@ sidebar:
 
             - id: vision
               title: _(Community Vision)
-              visibleDefault: false
+              visibleDefault: true
 
             - id: restoration
               title: _(Restoration Sites)
@@ -729,6 +737,286 @@ place:
 
   #### begin dynamic form config ####
   place_detail:
+    - category: park
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-parks_comp.png
+      value: park
+      label: _(Park)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: rail
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-transp_comp.png
+      value: rail
+      label: _(Rail)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: school
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-qual_comp.png
+      value: school
+      label: _(School)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: town-hall
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-hist_comp.png
+      value: town-hall
+      label: _(Town hall)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: wetland
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-land_comp.png
+      value: wetland
+      label: _(Wetland)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: police
+      includeOnForm: false
+      name: location_type
+      dataset: vision
+      icon_url: /static/css/images/markers/marker-safe_comp.png
+      value: police
+      label: _(Police)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: mapbox
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-star.png
+      value: mapbox
+      label: _(Mapbox)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: park2
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-heart.png
+      value: park2
+      label: _(Park2)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: industrial
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-industrial.png
+      value: industrial
+      label: _(Industrial)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: theatre
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-art.png
+      value: theatre
+      label: _(Theatre)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: swimming
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-swimming.png
+      value: swimming
+      label: _(Swimming)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: danger
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-construction.png
+      value: danger
+      label: _(Danger)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: bicycle
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-bike.png
+      value: bicycle
+      label: _(Bicycle)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
+    - category: zoo
+      includeOnForm: false
+      name: location_type
+      dataset: restoration
+      icon_url: /static/css/images/markers/marker-whale.png
+      value: zoo
+      label: _(Zoo)
+      fields:
+        - name: title
+          type: text
+          prompt: _(Title:)
+          placeholder: _(Enter title...)
+          display_prompt: ""
+          optional: false
+        - name: description
+          type: rawHTML
+          prompt: _(Raw HTML:)
+          display_prompt: ""
+          placeholder: _(Enter raw HTML...)
+          optional: true
     - category: observation
       includeOnForm: true
       name: location_type

--- a/src/sa_web/jstemplates/place-detail.html
+++ b/src/sa_web/jstemplates/place-detail.html
@@ -75,12 +75,12 @@
 
               {{#is type "textarea"}}
                 <p class="place-value place-value-{{ name }}">
-                  {{#if ../../isHTML}}
-                    {{{content}}}
-                  {{else}}
-                    {{nlToBr content}}
-                  {{/if}}
+                  {{nlToBr content}}
                 </p>
+              {{/is}}
+
+              {{#is type "rawHTML"}}
+                <p class="place-value place-value-{{ name }}">{{{content}}}</p>
               {{/is}}
 
               {{#is type "radio_big_buttons"}}

--- a/src/sa_web/jstemplates/place-detail.html
+++ b/src/sa_web/jstemplates/place-detail.html
@@ -1,51 +1,55 @@
         {{> place-detail-story-bar }}
 
-        {{> place-detail-promotion-bar }}
+        {{#unless isHTML}}
+          {{> place-detail-promotion-bar }}
+        {{/unless}}
 
         <header class="place-header clearfix">
-          <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
-            {{>location-string location }}
-            {{#if fullTitle}}
-              {{fullTitle}}
-            {{else}}
-              {{#if title}}
-                {{title}}
+          {{#unless isHTML}}
+            <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
+              {{>location-string location }}
+              {{#if fullTitle}}
+                {{fullTitle}}
               {{else}}
-                {{name}}
-              {{/if}}
-            {{/if}}
-          </h1>
-          <span class="place-submission-details">
-            {{#_}}<strong class="point-submitter">
-              {{#if submitter.avatar_url }}
-                <img src="{{ submitter.avatar_url }}" class="avatar" />
-              {{^}}
-                <img src="{{ STATIC_URL }}css/images/user-50.png" class="avatar" />
-              {{/if}}
-              {{#if submitter.name }}
-                {{ submitter.name }}
-              {{^}}
-                {{#if submitter_name }}
-                  {{ submitter_name }}
-                {{^}}
-                  {{ anonymous_name }}
+                {{#if title}}
+                  {{title}}
+                {{else}}
+                  {{name}}
                 {{/if}}
               {{/if}}
-            </strong> {{ action_text }} this {{ place_type_label location_type}}
+            </h1>
+            <span class="place-submission-details">
+              {{#_}}<strong class="point-submitter">
+                {{#if submitter.avatar_url }}
+                  <img src="{{ submitter.avatar_url }}" class="avatar" />
+                {{^}}
+                  <img src="{{ STATIC_URL }}css/images/user-50.png" class="avatar" />
+                {{/if}}
+                {{#if submitter.name }}
+                  {{ submitter.name }}
+                {{^}}
+                  {{#if submitter_name }}
+                    {{ submitter_name }}
+                  {{^}}
+                    {{ anonymous_name }}
+                  {{/if}}
+                {{/if}}
+              </strong> {{ action_text }} this {{ place_type_label location_type}}
 
-            {{#if region}}
-              in {{ region }}
-            {{/if}}{{/_}}
+              {{#if region}}
+                in {{ region }}
+              {{/if}}{{/_}}
 
-            <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a></time>
+              <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a></time>
 
-            <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
+              <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
 
             {{^if survey_config}}
               <a rel="internal" href="/{{ datasetSlug }}/{{ id }}" class="view-on-map-btn btn btn-small">View On Map</a>
             {{/if}}
 
-          </span>
+            </span>
+          {{/unless}}
         </header>
 
         <section class="place-items">
@@ -57,7 +61,9 @@
 
           {{#each_place_item "submitter_name" "name" "location_type" "fullTitle" "title" "name"}}
             <div class="place-item place-item-{{ name }}">
-              <span class="place-label place-label-{{ name }}">{{ prompt }}</span>
+              {{#unless ../isHTML}}
+                <span class="place-label place-label-{{ name }}">{{ prompt }}</span>
+              {{/unless}}
 
               {{#is type "datetime"}}
                 <p class="place-value place-value-{{ name }}">{{nlToBr content}}</p>
@@ -68,7 +74,13 @@
               {{/is}}
 
               {{#is type "textarea"}}
-                <p class="place-value place-value-{{ name }}">{{nlToBr content}}</p>
+                <p class="place-value place-value-{{ name }}">
+                  {{#if ../../isHTML}}
+                    {{{content}}}
+                  {{else}}
+                    {{nlToBr content}}
+                  {{/if}}
+                </p>
               {{/is}}
 
               {{#is type "radio_big_buttons"}}
@@ -121,8 +133,9 @@
         </section>
 
         {{#if survey_config}}
-
-        <section class="survey" id="survey"></section>
+          {{#unless isHTML}}
+            <section class="survey" id="survey"></section>
+          {{/unless}}
         {{/if}}
 
         {{> place-detail-story-bar-tagline }}

--- a/src/sa_web/jstemplates/place-detail.html
+++ b/src/sa_web/jstemplates/place-detail.html
@@ -5,20 +5,20 @@
         {{/unless}}
 
         <header class="place-header clearfix">
-          {{#unless isHTML}}
-            <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
-              {{>location-string location }}
-              {{#if fullTitle}}
-                {{fullTitle}}
+          <h1 class="place-header-title {{#if story}}is-visuallyhidden{{/if}}">
+            {{>location-string location }}
+            {{#if fullTitle}}
+              {{fullTitle}}
+            {{else}}
+              {{#if title}}
+                {{title}}
               {{else}}
-                {{#if title}}
-                  {{title}}
-                {{else}}
-                  {{name}}
-                {{/if}}
+                {{name}}
               {{/if}}
-            </h1>
-            <span class="place-submission-details">
+            {{/if}}
+          </h1>
+          <span class="place-submission-details">
+            {{#is_not showMetadata false}}
               {{#_}}<strong class="point-submitter">
                 {{#if submitter.avatar_url }}
                   <img src="{{ submitter.avatar_url }}" class="avatar" />
@@ -43,13 +43,13 @@
               <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a></time>
 
               <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
+            {{/is_not}}
 
-            {{^if survey_config}}
-              <a rel="internal" href="/{{ datasetSlug }}/{{ id }}" class="view-on-map-btn btn btn-small">View On Map</a>
-            {{/if}}
+          {{^if survey_config}}
+            <a rel="internal" href="/{{ datasetSlug }}/{{ id }}" class="view-on-map-btn btn btn-small">View On Map</a>
+          {{/if}}
 
-            </span>
-          {{/unless}}
+          </span>
         </header>
 
         <section class="place-items">

--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -91,6 +91,10 @@
           <textarea id="place-{{ name }}" name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}></textarea>
         {{/is}}
 
+        {{#is type "rawHTML"}}
+          <textarea id="place-{{ name }}" name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}></textarea>
+        {{/is}}
+
         {{#is type "radio_big_buttons"}}
           <div>
             {{#each content}}

--- a/src/sa_web/static/js/handlebars-helpers.js
+++ b/src/sa_web/static/js/handlebars-helpers.js
@@ -27,6 +27,10 @@ var Shareabouts = Shareabouts || {};
     return a === b ? options.fn(this) : options.inverse(this);
   });
 
+  Handlebars.registerHelper('is_not', function(a, b, options) {
+    return a !== b ? options.fn(this) : options.inverse(this);
+  });
+
   Handlebars.registerHelper('if_fileinput_not_supported', function(options) {    
     return !NS.Util.fileInputSupported() ? options.fn(this) : null;
   });

--- a/src/sa_web/static/js/handlebars-helpers.js
+++ b/src/sa_web/static/js/handlebars-helpers.js
@@ -189,7 +189,7 @@ var Shareabouts = Shareabouts || {};
       content, 
       wasAnswered = false;
 
-      if (fieldType === "text" || fieldType === "textarea" || fieldType === "datetime") {
+      if (fieldType === "text" || fieldType === "textarea" || fieldType === "datetime" || fieldType === "rawHTML") {
         // case: plain text
         content = userInput || "";
         if (content !== "") {

--- a/src/sa_web/static/js/views/layer-view.js
+++ b/src/sa_web/static/js/views/layer-view.js
@@ -71,7 +71,11 @@ var Shareabouts = Shareabouts || {};
           }
         } else {
           this.layer = L.GeoJSON.geometryToLayer(geom);
-          this.layer.setStyle(this.styleRule.style);
+          if (this.model.get("style")) {
+            this.layer.setStyle(this.model.get("style"));
+          } else {
+            this.layer.setStyle(this.styleRule.style);
+          }
         }
 
         // Focus on the layer onclick

--- a/src/sa_web/static/libs/leaflet.argo.js
+++ b/src/sa_web/static/libs/leaflet.argo.js
@@ -181,7 +181,7 @@ L.extend(L.Argo, {
     for (i=0, len=rules.length; i<len; i++) {
       // Replace the template with the property variable, not the value.
       // this is so we don't have to worry about strings vs nums.
-      condition = L.Argo.t(rules[i].condition, properties);
+      condition = L.Argo.t(rules[i].condition, (properties.style ? properties.style : properties));
 
       if (eval(condition)) {
         // The new property values (outlined in the config) are added for Leaflet compatibility


### PR DESCRIPTION
Addresses #407.

**NOT READY TO MERGE YET!** Still working on the migrations...

To handle landmark data in a shareabouts model, we're storing raw landmark HTML in the model's `description` field. We'll support this on the client side with a `rawHTML` form type, which will render (sanitized) landmark HTML directly in place detail views, and will correspond to a textarea field when in editor mode.

**TODO:**
- [x] How should we handle multiple marker types and styes (i.e. as found on the community vision layer)?
- [x] How to import geometry into shareabouts models? Can it be automated? What to do about polygons?
- [x] Support exporting shareabouts landmark data in geojson
- [x] Add a `rawHTML` form item, so arbitrary chunks of HTML can be combined with structured form elements
- [x] Figure out how to sanitize raw HTML
