### PR TITLE
use datasetSlug in links generated for notifcation emails

### DIFF
--- a/src/sa_web/templates/new_place_email_body.txt
+++ b/src/sa_web/templates/new_place_email_body.txt
@@ -1,3 +1,3 @@
 Thanks for submitting a new {{ place.properties.location_type }}!
 
-The URL for your place is http://{{ request.get_host }}/places/{{ place.id }}. Share it around.
+The URL for your place is http://{{ request.get_host }}/{{ place.properties.datasetSlug }}/{{ place.id }}. Share it around.


### PR DESCRIPTION
Fixes #26.

This turned out to be a simple fix: we just need to use `place.properties.datasetSlug` in the email body template. Unless I'm missing something, I think this is all we need to do?

I tested things using the following config object:

```
notifications:
  on_new_place: true
  submitter_email_field: private-submitter_email
```

The email body is generating correctly in the console. I have yet to receive an actual email, but I think that might be because I am not configured to send email from my localhost.