### PR TITLE
Pass reset: true option to map.fitBounds()

### DIFF
--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -649,7 +649,7 @@ var Shareabouts = Shareabouts || {};
                 map.setView(center, map.getMaxZoom()-1, {reset: true});
               }
             } else {
-              map.fitBounds(layer.getBounds());
+              map.fitBounds(layer.getBounds(), {reset: true});
             }
 
           } else {
@@ -810,7 +810,7 @@ var Shareabouts = Shareabouts || {};
                 map.setView(center, map.getMaxZoom()-1, {reset: true});
               }
             } else {
-              map.fitBounds(layer.getBounds());
+              map.fitBounds(layer.getBounds(), {reset: true});
             }
 
           } else {


### PR DESCRIPTION
Addresses: #504.

Although I don't completely understand why this helps, passing a `{reset: true}` parameter to our use of `map.fitBounds()` in the app view seems to prevent the map render bug we see on an initial load of a polygon landmark.

Not sure if this completely eliminates the problem, as I think it is still possible to trigger this bug through some sequence of interactions after initial page load, but hopefully this cuts down on instances of the bug.
