### PR TITLE
Goldpbear/lazy render list

### DIFF
--- a/src/sa_web/static/js/views/place-list-view.js
+++ b/src/sa_web/static/js/views/place-list-view.js
@@ -87,7 +87,6 @@ var Shareabouts = Shareabouts || {};
 
       _.each(this.options.placeCollections, function(collection) {
         collection.on("add", self.addModel, self);
-        collection.on("sync", self.onSync, self);
       });
 
       this.itemsPerPage = 10;
@@ -103,20 +102,15 @@ var Shareabouts = Shareabouts || {};
       this.collectionFilters = options.filter || {};
       this.searchTerm = options.term || '';
     },
-    onSync: function() {
-      // sort the merged collection after each component collection
-      // is synced successfully
-      this.sort();
-    },
     onAfterItemAdded: function(view) {
       // Cache the views as they are added
       this.views[view.model.cid] = view;
     },
     addModel: function(model) {
       if (this.collection.length < this.numItemsShown) {
-        this.collection.add(model);
+        this.collection.add(model, {sort: false});
       } else {
-        this.unrenderedItems.add(model);
+        this.unrenderedItems.add(model, {sort: false});
       }
     },
     renderList: function() {

--- a/src/sa_web/static/js/views/place-list-view.js
+++ b/src/sa_web/static/js/views/place-list-view.js
@@ -71,7 +71,8 @@ var Shareabouts = Shareabouts || {};
       'submit @ui.searchForm': 'handleSearchSubmit',
       'click @ui.date': 'handleDateSort',
       'click @ui.surveyCount': 'handleSurveyCountSort',
-      'click @ui.supportCount': 'handleSupportCountSort'
+      'click @ui.supportCount': 'handleSupportCountSort',
+      'scroll': 'infiniteScroll'
     },
     initialize: function(options) {
       var self = this;
@@ -85,6 +86,9 @@ var Shareabouts = Shareabouts || {};
         collection.on("add", self.addModel, self);
         collection.on("sync", self.onSync, self);
       });
+
+      this.itemsPerPage = 10;
+      this.numItemsShown = this.itemsPerPage;
 
       // Init the views cache
       this.views = {};
@@ -116,8 +120,8 @@ var Shareabouts = Shareabouts || {};
       var $itemViewContainer = this.getItemViewContainer(this);
       $itemViewContainer.empty();
 
-      this.collection.each(function(model) {
-        if (self.views[model.cid]) {
+      this.collection.each(function(model, index) {
+        if (self.views[model.cid] && index < self.numItemsShown) {
           $itemViewContainer.append(self.views[model.cid].$el);
           // Delegate the events so that the subviews still work
           self.views[model.cid].supportView.delegateEvents();
@@ -127,17 +131,28 @@ var Shareabouts = Shareabouts || {};
       // remove story bars from the list view
       $("#list-container .place-story-bar").remove();
     },
+    infiniteScroll: function() {
+      var totalHeight = this.$('> ul').height();
+      var scrollTop = this.$el.scrollTop() + this.$el.height();
+      // 200 = number of pixels from bottom to load more
+      if (scrollTop + 200 >= totalHeight) {
+        this.numItemsShown += this.itemsPerPage;
+        this.renderList();
+      }
+    },
     handleSearchInput: function(evt) {
       evt.preventDefault();
+      this.numItemsShown = this.itemsPerPage;
       this.search(this.ui.searchField.val());
     },
     handleSearchSubmit: function(evt) {
       evt.preventDefault();
+      this.numItemsShown = this.itemsPerPage;
       this.search(this.ui.searchField.val());
     },
     handleDateSort: function(evt) {
       evt.preventDefault();
-
+      this.numItemsShown = this.itemsPerPage;
       this.sortBy = 'date';
       this.sort();
 
@@ -145,7 +160,7 @@ var Shareabouts = Shareabouts || {};
     },
     handleSurveyCountSort: function(evt) {
       evt.preventDefault();
-
+      this.numItemsShown = this.itemsPerPage;
       this.sortBy = 'surveyCount';
       this.sort();
 
@@ -153,7 +168,7 @@ var Shareabouts = Shareabouts || {};
     },
     handleSupportCountSort: function(evt) {
       evt.preventDefault();
-
+      this.numItemsShown = this.itemsPerPage;
       this.sortBy = 'supportCount';
       this.sort();
 

--- a/src/sa_web/static/js/views/place-list-view.js
+++ b/src/sa_web/static/js/views/place-list-view.js
@@ -44,6 +44,7 @@ var Shareabouts = Shareabouts || {};
       }
     },
     onRender: function(evt) {
+      this.support.reset();
       this.support.show(this.supportView);
     },
     show: function() {


### PR DESCRIPTION
* Remove per-model and per-sync sorting to improve performance
* To correct an issue where not all list items render their support view, call `this.support.reset()` in the `onRender()` method of `PlaceListItemView`. This seems to solve the issue, although I can't satisfactorily explain why. I have a feeling the root cause of this issue might lie elsewhere, but I'm stumped as to where.