### PR TITLE
Fix meter bar display issues

### DIFF
--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -2188,14 +2188,16 @@ ul.recent-points {
 
 .meter-bar meter {
   width: 260px;
-  height: 10px;
-  -webkit-appearance: none;
   border: 1px solid #ccc;
   border-radius: 3px;
   display: inline-block;
   *display: inline;
   *zoom: 1;
   padding: 0.1em 0.1em;
+}
+
+.meter-bar meter::-webkit-meter-bar {
+  border: 1px solid #ccc;
 }
 
 #geocode-address-bar {

--- a/src/sa_web/static/js/views/place-counter-view.js
+++ b/src/sa_web/static/js/views/place-counter-view.js
@@ -8,7 +8,7 @@ var Shareabouts = Shareabouts || {};
       var self = this;
       self.numberOfPlaces = 0;
 
-      _.each(this.options.places.duwamish, function(collection) {
+      _.each(this.options.places, function(collection) {
         self.numberOfPlaces += collection.models.length;
 
         // Bind data events

--- a/src/sa_web/static/scss/_counter.scss
+++ b/src/sa_web/static/scss/_counter.scss
@@ -34,14 +34,14 @@
 
 .meter-bar meter {
     width: 260px;
-    height: 10px;
-    -webkit-appearance: none;
-
-    // Reset appearance
     border: 1px solid #ccc;
     border-radius: 3px;
     display: inline-block;
     *display: inline;
     *zoom: 1;
     padding: 0.1em 0.1em;
+}
+
+.meter-bar meter::-webkit-meter-bar {
+    border: 1px solid #ccc;
 }


### PR DESCRIPTION
Fixes #509.

* Refactor `place-counter-view.js` to count models over all place collections
* To fix meter bar display issues on Chrome, remove `-webkit-appearance: none` style and use the `-webkit-meter-bar` pseudo-selector to enforce styling in Chrome