### PR TITLE
add form section header and description field types

### DIFF
--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -65,8 +65,14 @@
     <!-- generate content for selected category -->
     {{#each selectedCategory.fields}}
       <div class="{{ type }} form-field">
-        <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
-        
+        {{#if horizontal_rule}}
+          <hr />
+        {{/if}}
+
+        {{#if prompt}}
+          <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
+        {{/if}}
+
         <!-- begin field type definitions -->
         {{#is type "geocoding"}}
           <div class="geocoding-enabled">
@@ -129,6 +135,14 @@
           <div style="clear:both"></div>
         {{/is}}
         <div style="clear:both"></div>
+
+        {{#is type "section_header"}}
+          <h3 id={{ name }} class="form-section-header">{{content}}</h3>
+        {{/is}}
+        
+        {{#is type "section_description"}}
+          <p id={{ name }} class="form-section-description">{{content}}</p>
+        {{/is}}
 
         <!-- optional post-form field message -->
         {{#if annotation}}


### PR DESCRIPTION
This PR adds two new dynamic form field types: `section_header`, and `section_description`. Neither type accepts input. Use them like this:

```
- name: demographics-header
  type: section_header
  horizontal_rule: true
  content: _(Some section header)
- name: demographics-description
  type: section_description
  content: _(This is my description of this section of the form)
```

The `horizontal_rule: true` flag is optional, but if it is set to `true` the form will render a horizontal line above the element.

By default, section headers are `<h3>` tags, and section descriptions are `<p>` tags. There is no additional default styling, but style rules can be added in a flavor's `custom.css` file using these selectors: `.form-section-header` and `.form-section-description`. For example:

```
.form-section-header {
    color: red;
}
```