### PR TITLE
Add form autocompletion to pboakland flavor

### DIFF
--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -324,7 +324,6 @@ place:
 
   location_item_name: location
 
-
   #### begin dynamic form config ####
   place_detail:
     - category: youth
@@ -352,73 +351,6 @@ place:
           prompt: _(Why is this important? What need in the community does this serve?:)
           display_prompt: _( )
           placeholder: _( )
-          optional: true          
-        - name: private-phone
-          type: text
-          prompt: _(Your phone number:)
-          display_prompt: _()
-          placeholder: _(Your phone number will not appear on the map)
-          optional: true
-        - name: private-age
-          type: text
-          prompt: _(Your age:)
-          display_prompt: _()
-          placeholder: _(Your age will not appear on the map)
-          optional: true
-        - name: private-ethnicity
-          type: radio_big_buttons
-          annotation: _(Your ethnicity will not appear on the map)
-          prompt: _(Your ethnicity:)
-          display_prompt: _(Ethnicity:)
-          content:
-            - label: _(American Indian/Alaskan Native)
-              value: indian-alaskan
-            - label: _(Asian)
-              value: asian
-            - label: _(Black or African American)
-              value: black
-            - label: _(Hispanic or Latino/a)
-              value: hispanic
-            - label: _(Native Hawaiian or Pacific Islander)
-              value: hawaiian-pacific
-            - label: _(White)
-              value: white
-            - label: _(Other)
-              value: other
-          optional: true
-        - name: private-income
-          type: dropdown
-          prompt: _(Your income:)
-          annotation: _(Your income will not appear on the map)
-          content:
-            - label: _(Under $10,000)
-              value: under-10k
-            - label: _($10,000 - $14,999)
-              value: 10k-15k
-            - label: _($15,000 - $24,999)
-              value: 15k-25k
-            - label: _($25,000 - $34,999)
-              value: 25k-35k
-            - label: _($35,000 - $49,000)
-              value: 35k-49k
-            - label: _($50,000 - $74,999)
-              value: 50k-75k
-            - label: _($75,000 - $99,000)
-              value: 75k-99k
-            - label: _($100,000 - $149,000)
-              value: 100k-149k
-            - label: _($150,000 or more)
-              value: 150k-or-more
-          optional: true
-        - name: private-volunteer
-          type: binary_toggle
-          prompt: _(I want to volunteer:)
-          display_prompt: _(I want to volunteer:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
           optional: true
     - category: senior
       includeOnForm: true
@@ -445,73 +377,6 @@ place:
           prompt: _(Why is this important? What need in the community does this serve?:)
           display_prompt: _( )
           placeholder: _( )
-          optional: true          
-        - name: private-phone
-          type: text
-          prompt: _(Your phone number:)
-          display_prompt: _()
-          placeholder: _(Your phone number will not appear on the map)
-          optional: true
-        - name: private-age
-          type: text
-          prompt: _(Your age:)
-          display_prompt: _()
-          placeholder: _(Your age will not appear on the map)
-          optional: true
-        - name: private-ethnicity
-          type: radio_big_buttons
-          annotation: _(Your ethnicity will not appear on the map)
-          prompt: _(Your ethnicity:)
-          display_prompt: _(Ethnicity:)
-          content:
-            - label: _(American Indian/Alaskan Native)
-              value: indian-alaskan
-            - label: _(Asian)
-              value: asian
-            - label: _(Black or African American)
-              value: black
-            - label: _(Hispanic or Latino/a)
-              value: hispanic
-            - label: _(Native Hawaiian or Pacific Islander)
-              value: hawaiian-pacific
-            - label: _(White)
-              value: white
-            - label: _(Other)
-              value: other
-          optional: true
-        - name: private-income
-          type: dropdown
-          prompt: _(Your income:)
-          annotation: _(Your income will not appear on the map)
-          content:
-            - label: _(Under $10,000)
-              value: under-10k
-            - label: _($10,000 - $14,999)
-              value: 10k-15k
-            - label: _($15,000 - $24,999)
-              value: 15k-25k
-            - label: _($25,000 - $34,999)
-              value: 25k-35k
-            - label: _($35,000 - $49,000)
-              value: 35k-49k
-            - label: _($50,000 - $74,999)
-              value: 50k-75k
-            - label: _($75,000 - $99,000)
-              value: 75k-99k
-            - label: _($100,000 - $149,000)
-              value: 100k-149k
-            - label: _($150,000 or more)
-              value: 150k-or-more
-          optional: true
-        - name: private-volunteer
-          type: binary_toggle
-          prompt: _(I want to volunteer:)
-          display_prompt: _(I want to volunteer:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
           optional: true
     - category: parks
       includeOnForm: true
@@ -538,73 +403,6 @@ place:
           prompt: _(Why is this important? What need in the community does this serve?:)
           display_prompt: _( )
           placeholder: _( )
-          optional: true          
-        - name: private-phone
-          type: text
-          prompt: _(Your phone number:)
-          display_prompt: _()
-          placeholder: _(Your phone number will not appear on the map)
-          optional: true
-        - name: private-age
-          type: text
-          prompt: _(Your age:)
-          display_prompt: _()
-          placeholder: _(Your age will not appear on the map)
-          optional: true
-        - name: private-ethnicity
-          type: radio_big_buttons
-          annotation: _(Your ethnicity will not appear on the map)
-          prompt: _(Your ethnicity:)
-          display_prompt: _(Ethnicity:)
-          content:
-            - label: _(American Indian/Alaskan Native)
-              value: indian-alaskan
-            - label: _(Asian)
-              value: asian
-            - label: _(Black or African American)
-              value: black
-            - label: _(Hispanic or Latino/a)
-              value: hispanic
-            - label: _(Native Hawaiian or Pacific Islander)
-              value: hawaiian-pacific
-            - label: _(White)
-              value: white
-            - label: _(Other)
-              value: other
-          optional: true
-        - name: private-income
-          type: dropdown
-          prompt: _(Your income:)
-          annotation: _(Your income will not appear on the map)
-          content:
-            - label: _(Under $10,000)
-              value: under-10k
-            - label: _($10,000 - $14,999)
-              value: 10k-15k
-            - label: _($15,000 - $24,999)
-              value: 15k-25k
-            - label: _($25,000 - $34,999)
-              value: 25k-35k
-            - label: _($35,000 - $49,000)
-              value: 35k-49k
-            - label: _($50,000 - $74,999)
-              value: 50k-75k
-            - label: _($75,000 - $99,000)
-              value: 75k-99k
-            - label: _($100,000 - $149,000)
-              value: 100k-149k
-            - label: _($150,000 or more)
-              value: 150k-or-more
-          optional: true
-        - name: private-volunteer
-          type: binary_toggle
-          prompt: _(I want to volunteer:)
-          display_prompt: _(I want to volunteer:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
           optional: true
     - category: streets
       includeOnForm: true
@@ -631,73 +429,6 @@ place:
           prompt: _(Why is this important? What need in the community does this serve?:)
           display_prompt: _( )
           placeholder: _( )
-          optional: true          
-        - name: private-phone
-          type: text
-          prompt: _(Your phone number:)
-          display_prompt: _()
-          placeholder: _(Your phone number will not appear on the map)
-          optional: true
-        - name: private-age
-          type: text
-          prompt: _(Your age:)
-          display_prompt: _()
-          placeholder: _(Your age will not appear on the map)
-          optional: true
-        - name: private-ethnicity
-          type: radio_big_buttons
-          annotation: _(Your ethnicity will not appear on the map)
-          prompt: _(Your ethnicity:)
-          display_prompt: _(Ethnicity:)
-          content:
-            - label: _(American Indian/Alaskan Native)
-              value: indian-alaskan
-            - label: _(Asian)
-              value: asian
-            - label: _(Black or African American)
-              value: black
-            - label: _(Hispanic or Latino/a)
-              value: hispanic
-            - label: _(Native Hawaiian or Pacific Islander)
-              value: hawaiian-pacific
-            - label: _(White)
-              value: white
-            - label: _(Other)
-              value: other
-          optional: true
-        - name: private-income
-          type: dropdown
-          prompt: _(Your income:)
-          annotation: _(Your income will not appear on the map)
-          content:
-            - label: _(Under $10,000)
-              value: under-10k
-            - label: _($10,000 - $14,999)
-              value: 10k-15k
-            - label: _($15,000 - $24,999)
-              value: 15k-25k
-            - label: _($25,000 - $34,999)
-              value: 25k-35k
-            - label: _($35,000 - $49,000)
-              value: 35k-49k
-            - label: _($50,000 - $74,999)
-              value: 50k-75k
-            - label: _($75,000 - $99,000)
-              value: 75k-99k
-            - label: _($100,000 - $149,000)
-              value: 100k-149k
-            - label: _($150,000 or more)
-              value: 150k-or-more
-          optional: true
-        - name: private-volunteer
-          type: binary_toggle
-          prompt: _(I want to volunteer:)
-          display_prompt: _(I want to volunteer:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
           optional: true
     - category: health
       includeOnForm: true
@@ -725,81 +456,89 @@ place:
           display_prompt: _( )
           placeholder: _( )
           optional: true          
-        - name: private-phone
-          type: text
-          prompt: _(Your phone number:)
-          display_prompt: _()
-          placeholder: _(Your phone number will not appear on the map)
-          optional: true
-        - name: private-age
-          type: text
-          prompt: _(Your age:)
-          display_prompt: _()
-          placeholder: _(Your age will not appear on the map)
-          optional: true
-        - name: private-ethnicity
-          type: radio_big_buttons
-          annotation: _(Your ethnicity will not appear on the map)
-          prompt: _(Your ethnicity:)
-          display_prompt: _(Ethnicity:)
-          content:
-            - label: _(American Indian/Alaskan Native)
-              value: indian-alaskan
-            - label: _(Asian)
-              value: asian
-            - label: _(Black or African American)
-              value: black
-            - label: _(Hispanic or Latino/a)
-              value: hispanic
-            - label: _(Native Hawaiian or Pacific Islander)
-              value: hawaiian-pacific
-            - label: _(White)
-              value: white
-            - label: _(Other)
-              value: other
-          optional: true
-        - name: private-income
-          type: dropdown
-          prompt: _(Your income:)
-          annotation: _(Your income will not appear on the map)
-          content:
-            - label: _(Under $10,000)
-              value: under-10k
-            - label: _($10,000 - $14,999)
-              value: 10k-15k
-            - label: _($15,000 - $24,999)
-              value: 15k-25k
-            - label: _($25,000 - $34,999)
-              value: 25k-35k
-            - label: _($35,000 - $49,000)
-              value: 35k-49k
-            - label: _($50,000 - $74,999)
-              value: 50k-75k
-            - label: _($75,000 - $99,000)
-              value: 75k-99k
-            - label: _($100,000 - $149,000)
-              value: 100k-149k
-            - label: _($150,000 or more)
-              value: 150k-or-more
-          optional: true
-        - name: private-volunteer
-          type: binary_toggle
-          prompt: _(I want to volunteer:)
-          display_prompt: _(I want to volunteer:)
-          content:
-            - label: _(Yes)
-              value: "yes"
-            - label: _(No)
-              value: "no"
-          optional: true
+
   # define form elements that appear on every form here
   common_form_elements:
+    - name: private-phone
+      autocomplete: true
+      type: text
+      prompt: _(Your phone number:)
+      display_prompt: _()
+      placeholder: _(Your phone number will not appear on the map)
+      optional: true
+    - name: private-age
+      autocomplete: true
+      type: text
+      prompt: _(Your age:)
+      display_prompt: _()
+      placeholder: _(Your age will not appear on the map)
+      optional: true
+    - name: private-ethnicity
+      autocomplete: true
+      type: radio_big_buttons
+      annotation: _(Your ethnicity will not appear on the map)
+      prompt: _(Your ethnicity:)
+      display_prompt: _(Ethnicity:)
+      content:
+        - label: _(American Indian/Alaskan Native)
+          value: indian-alaskan
+        - label: _(Asian)
+          value: asian
+        - label: _(Black or African American)
+          value: black
+        - label: _(Hispanic or Latino/a)
+          value: hispanic
+        - label: _(Native Hawaiian or Pacific Islander)
+          value: hawaiian-pacific
+        - label: _(White)
+          value: white
+        - label: _(Other)
+          value: other
+      optional: true
+    - name: private-income
+      autocomplete: true
+      type: dropdown
+      prompt: _(Your income:)
+      annotation: _(Your income will not appear on the map)
+      content:
+        - label: _(Under $10,000)
+          value: under-10k
+        - label: _($10,000 - $14,999)
+          value: 10k-15k
+        - label: _($15,000 - $24,999)
+          value: 15k-25k
+        - label: _($25,000 - $34,999)
+          value: 25k-35k
+        - label: _($35,000 - $49,000)
+          value: 35k-49k
+        - label: _($50,000 - $74,999)
+          value: 50k-75k
+        - label: _($75,000 - $99,000)
+          value: 75k-99k
+        - label: _($100,000 - $149,000)
+          value: 100k-149k
+        - label: _($150,000 or more)
+          value: 150k-or-more
+      optional: true
+    - name: private-volunteer
+      autocomplete: true
+      type: binary_toggle
+      prompt: _(I want to volunteer:)
+      display_prompt: _(I want to volunteer:)
+      content:
+        - label: _(Yes)
+          value: "yes"
+        - label: _(No)
+          value: "no"
+      optional: true
     - name: submitter_name
+      autocomplete: true
       type: text
       prompt: _(Your name)
       placeholder: _(Name)
       optional: true
     - name: private-submitter_email
+      autocomplete: true
       type: text
       prompt: _(Your Email)
       placeholder: _(Receive email updates on your idea)

--- a/src/flavors/pboakland/config.yml
+++ b/src/flavors/pboakland/config.yml
@@ -802,13 +802,9 @@ place:
     - name: private-submitter_email
       type: text
       prompt: _(Your Email)
+      placeholder: _(Receive email updates on your idea)
       optional: true
       sticky: true
-      attrs:
-        - key: placeholder
-          value: _(Receive email updates on your idea)
-        - key: size
-          value: 30
     - name: my_image
       type: file
       prompt: _(Image)

--- a/src/sa_web/jstemplates/place-form-field-types.html
+++ b/src/sa_web/jstemplates/place-form-field-types.html
@@ -1,0 +1,152 @@
+{{#is type "geocoding"}}
+  <div class="geocoding-enabled">
+    <div id="geocode-address-place-bar" class="clearfix">
+      <p class="error is-hidden"></p>
+      <label class="geocode-address-label" for="geocode-address-field"></label>
+      <div class="geocode-spinner is-hidden"></div>
+      <input name="{{ name }}" 
+             {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} 
+             type="text" 
+             id="geocode-address-field" 
+             class="geocode-address-field"
+             value={{autocompleteValue}}>
+    </div>
+  </div>
+{{/is}}
+
+{{#is type "datetime"}}
+  <input id="datetimepicker" 
+         name="{{ name }}" 
+         type="text"
+         {{#if autocompleteValue}}class="isAutocomplete"{{/if}}
+         {{^optional}}required{{/optional}}
+         value={{autocompleteValue}}>
+{{/is}}
+
+{{#is type "text"}}
+  <input id="place-{{ name }}" 
+         {{#if autocompleteValue}}class="isAutocomplete"{{/if}}
+         name="{{ name }}" 
+         type="{{ type }}" 
+         {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} 
+         {{#unless autocompleteValue}} placeholder="{{ placeholder }}"{{/unless}}
+         placeholder="{{placeholder}}" 
+         {{^optional}}required{{/optional}}
+         value={{autocompleteValue}}>
+{{/is}}
+
+{{#is type "textarea"}}
+  <textarea id="place-{{ name }}" 
+            {{#if autocompleteValue}}class="isAutocomplete"{{/if}}
+            name="{{ name }}" 
+            {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} 
+            {{#unless autocompleteValue}} placeholder="{{ placeholder }}"{{/unless}}
+            {{^optional}}required{{/optional}}>{{autocompleteValue}}</textarea>
+{{/is}}
+
+{{#is type "radio_big_buttons"}}
+  <div>
+    {{#each content}}
+        <input type="radio" 
+               name={{ ../name }} 
+               id={{ value }} 
+               value={{ value }} 
+               class="big-btn" 
+               {{^../optional}}required{{/../optional}}
+               {{#contains value ../autocompleteValue}}checked{{/contains}}>
+        <label for={{ value }}
+               class="{{#contains value ../autocompleteValue}}isAutocomplete{{/contains}}">{{ label }}</label>
+    {{/each}}
+  </div>
+  <div style="clear:both"></div>
+{{/is}}
+
+{{#is type "checkbox_big_buttons"}}
+  <div>
+    {{#each content}}
+      <input type="checkbox" 
+             name={{ ../name }} 
+             id={{ value }} 
+             value={{ value }} 
+             class="big-btn"
+             {{#contains value ../autocompleteValue}}checked{{/contains}}>
+      <label for={{ value }}
+             class="{{#contains value ../autocompleteValue}}isAutocomplete{{/contains}}">{{ label }}</label>
+    {{/each}}
+  </div>
+{{/is}}
+
+{{#is type "binary_toggle"}}
+  <div>
+    <input type="checkbox" 
+           name={{ name }} 
+           id={{ name }} 
+           value={{#if autocompleteValue}}
+                   {{ autocompleteValue }}
+                 {{else}}
+                   {{ content.[1].value }}
+                 {{/if}}
+           data-input-type="binary_toggle" 
+           class="big-btn"
+           {{#is autocompleteValue content.[0].value}}checked{{/is}}>
+    <label for={{ name }}
+           {{#if autocompleteValue}}class="isAutocomplete"{{/if}}>
+      {{#if autocompleteValue}}
+        {{#is autocompleteValue content.[0].value}}
+          {{content.[0].label}}
+        {{/is}}
+        {{#is autocompleteValue content.[1].value}}
+          {{content.[1].label}}
+        {{/is}}
+      {{else}}
+        {{content.[1].label}}
+      {{/if}}
+    </label>
+  </div>
+{{/is}}
+
+{{#is type "dropdown"}}
+  <div>
+    <select name={{ ../name }} 
+            {{^optional}}required{{/optional}}
+            {{#autocompleteValue}}class="isAutocomplete"{{/autocompleteValue}}>
+      <option value="" name="no_response">{{#_}}Select...{{/_}}</option>
+      {{#each content}}
+          <option value={{value}} {{#is value ../autocompleteValue}}selected{{/is}}>{{label}}</option>
+      {{/each}}
+    </select>
+  </div>
+  <div style="clear:both"></div>
+{{/is}}
+<div style="clear:both"></div>
+
+{{#is type "section_header"}}
+  <h3 id={{ name }} class="form-section-header">{{content}}</h3>
+{{/is}}
+
+{{#is type "section_description"}}
+  <p id={{ name }} class="form-section-description">{{content}}</p>
+{{/is}}
+
+{{#is type "file"}}
+  <span class="fileinput-container btn btn-small{{#if_fileinput_not_supported}} btn-disabled{{/if_fileinput_not_supported}}">
+    <span>{{ inputfile_label }}</span>
+    <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}"
+           {{#attrs}} {{ key }}="{{ value }}"{{/attrs}}
+           {{#if_fileinput_not_supported}} disabled{{/if_fileinput_not_supported}}>
+  </span>
+  <span class="fileinput-name">
+    {{#if_fileinput_not_supported}}Sorry, your browser doesn't support file uploads.{{/if_fileinput_not_supported}}
+  </span>
+{{/is}}
+
+{{#is type "submit"}}
+  <div>
+    <input name="save-place-btn" id="save-place-btn" type="submit" value="{{ label }}" class="btn btn-primary submit-btn">
+  </div>
+{{/is}}
+
+<!-- optional post-form field message -->
+{{#if annotation}}
+  <div class="form-annotation">{{annotation}}</div>
+{{/if}}

--- a/src/sa_web/jstemplates/place-form.html
+++ b/src/sa_web/jstemplates/place-form.html
@@ -35,10 +35,10 @@
     {{#if isCategorySelected}}
       {{#unless isSingleCategory}}
         <div id="selected-category">
-          <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selectedCategory.name }} value={{ selectedCategory.value }} checked>
+          <input type="radio" id="selected-category-placeholder" class="category-btn" name={{ selectedCategoryConfig.name }} value={{ selectedCategoryConfig.value }} checked>
           <label for="selected-category-palceholder">
-            <img src={{ selectedCategory.icon_url }} />
-            <span>{{ selectedCategory.label }}</span>
+            <img src={{ selectedCategoryConfig.icon_url }} />
+            <span>{{ selectedCategoryConfig.label }}</span>
           </label>
           <span class="category-menu-hamburger"></span>
         </div>
@@ -63,7 +63,7 @@
     {{/unless}}
 
     <!-- generate content for selected category -->
-    {{#each selectedCategory.fields}}
+    {{#each selectedCategoryConfig.fields}}
       <div class="{{ type }} form-field">
         {{#if horizontal_rule}}
           <hr />
@@ -73,83 +73,7 @@
           <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
         {{/if}}
 
-        <!-- begin field type definitions -->
-        {{#is type "geocoding"}}
-          <div class="geocoding-enabled">
-            <div id="geocode-address-place-bar" class="clearfix">
-              <p class="error is-hidden"></p>
-              <label class="geocode-address-label" for="geocode-address-field"></label>
-              <div class="geocode-spinner is-hidden"></div>
-              <input name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} type="text" id="geocode-address-field" class="geocode-address-field">
-            </div>
-          </div>
-        {{/is}}
-        
-        {{#is type "datetime"}}
-          <input id="datetimepicker" name="{{ name }}" type="text" {{^optional}}required{{/optional}}>
-        {{/is}}
-
-        {{#is type "text"}}
-          <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}>
-        {{/is}}
-
-        {{#is type "textarea"}}
-          <textarea id="place-{{ name }}" name="{{ name }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}" {{^optional}}required{{/optional}}></textarea>
-        {{/is}}
-
-        {{#is type "radio_big_buttons"}}
-          <div>
-            {{#each content}}
-                <input type="radio" name={{ ../name }} id={{ value }} value={{ value }} class="big-btn" {{^../optional}}required{{/../optional}}>
-                <label for={{ value }}>{{ label }}</label>
-            {{/each}}
-          </div>
-          <div style="clear:both"></div>
-        {{/is}}
-
-        {{#is type "checkbox_big_buttons"}}
-          <div>
-            {{#each content}}
-              <input type="checkbox" name={{ ../name }} id={{ value }} value={{ value }} class="big-btn">
-              <label for={{ value }}>{{ label }}</label>
-            {{/each}}
-          </div>
-        {{/is}}
-
-        {{#is type "binary_toggle"}}
-          <div>
-            <input type="checkbox" name={{ name }} id={{ name }} value={{ content.[1].value }} data-input-type="binary_toggle" class="big-btn">
-            <label for={{ name }}>{{ content.[1].label }}</label>
-          </div>
-        {{/is}}
-
-        {{#is type "dropdown"}}
-          <div>
-            <select name={{ ../name }} {{^optional}}required{{/optional}}>
-              <option value="" name="no_response">{{#_}}Select...{{/_}}</option>
-              {{#each content}}
-                  <option value={{value}}>{{label}}</option>
-              {{/each}}
-            </select>
-          </div>
-          <div style="clear:both"></div>
-        {{/is}}
-        <div style="clear:both"></div>
-
-        {{#is type "section_header"}}
-          <h3 id={{ name }} class="form-section-header">{{content}}</h3>
-        {{/is}}
-        
-        {{#is type "section_description"}}
-          <p id={{ name }} class="form-section-description">{{content}}</p>
-        {{/is}}
-
-        <!-- optional post-form field message -->
-        {{#if annotation}}
-          <div class="form-annotation">{{annotation}}</div>
-        {{/if}}
-
-        <!-- end field type definitions -->
+        {{> place-form-field-types }}
       </div>
     {{/each}}
 
@@ -158,37 +82,8 @@
       <div id="common-form-elements">
         {{#each placeConfig.common_form_elements }}
           <div class="{{ this.type }} form-field">
-            {{#is name "submitter_name"}}
-              {{#if_not_authenticated}}
-                <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
-                <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} value="{{get_value ../../../.. name}}" placeholder="{{placeholder}}">
-                <!--<span class="or-sign-in">{{#_}}Or sign in with <a class="auth-inline twitter-btn" href="/users/login/twitter/">Twitter</a> <a class="auth-inline facebook-btn" href="/users/login/facebook/">Facebook</a>{{/_}}</span>-->
-              {{/if_not_authenticated}}
-            {{/is}}
-
-            {{#is name "private-submitter_email"}}
-              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
-              <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}" {{#attrs}} {{ key }}="{{ value }}"{{/attrs}} placeholder="{{placeholder}}">
-            {{/is}}
-
-            {{#is type "file"}}
-              <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>
-              <span class="fileinput-container btn btn-small{{#if_fileinput_not_supported}} btn-disabled{{/if_fileinput_not_supported}}">
-                <span>{{ inputfile_label }}</span>
-                <input id="place-{{ name }}" name="{{ name }}" type="{{ type }}"
-                       {{#attrs}} {{ key }}="{{ value }}"{{/attrs}}
-                       {{#if_fileinput_not_supported}} disabled{{/if_fileinput_not_supported}}>
-              </span>
-              <span class="fileinput-name">
-                {{#if_fileinput_not_supported}}Sorry, your browser doesn't support file uploads.{{/if_fileinput_not_supported}}
-              </span>
-            {{/is}}
-
-            {{#is type "submit"}}
-              <div>
-                <input name="save-place-btn" id="save-place-btn" type="submit" value="{{ label }}" class="btn btn-primary submit-btn">
-              </div>
-            {{/is}}
+            <label for="place-{{ name }}">{{ prompt }} {{# optional }}<small>({{#_}}optional{{/_}})</small>{{/ optional }}</label>          
+            {{> place-form-field-types }}
           </div>
         {{/each}}
       </div>

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -1088,6 +1088,10 @@ select {
   display: none;
 }
 
+.isAutocomplete {
+  background-color: #ffffe0;
+}
+
 #site-header {
   position: relative;
   z-index: 99;

--- a/src/sa_web/static/js/handlebars-helpers.js
+++ b/src/sa_web/static/js/handlebars-helpers.js
@@ -170,6 +170,11 @@ var Shareabouts = Shareabouts || {};
     return $el.html();
   });
 
+  Handlebars.registerHelper("contains", function( value, array, options ){
+    array = ( array instanceof Array ) ? array : [array];
+    return (array.indexOf(value) > -1) ? options.fn( this ) : "";
+  });
+
   Handlebars.registerHelper('each_place_item', function() {
     var self = this,
         result = '',

--- a/src/sa_web/static/js/utils.js
+++ b/src/sa_web/static/js/utils.js
@@ -58,6 +58,24 @@ var Shareabouts = Shareabouts || {};
       return attrs;
     },
 
+    // attempt to save form autocomplete values in localStorage;
+    // fall back to cookies
+    saveAutocompleteValue: function(name, value, days) {
+      if (typeof Storage !== "undefined") {
+        this.localstorage.save(name, value, days);
+      } else {
+        this.cookies.save(name, value, days, "mapseed-");
+      }
+    },
+ 
+    getAutocompleteValue: function(name) {
+      if (typeof Storage !== "undefined") {
+        return this.localstorage.get(name);
+      } else {
+        return this.cookies.get(name, "mapseed-");
+      }
+    },
+
     findPageConfig: function(pagesConfig, properties) {
       // Search the first level for the page config
       var pageConfig = _.findWhere(pagesConfig, properties);
@@ -335,8 +353,10 @@ var Shareabouts = Shareabouts || {};
     // Cookies! Om nom nom
     // Thanks ppk! http://www.quirksmode.org/js/cookies.html
     cookies: {
-      save: function(name,value,days) {
-        var expires;
+      save: function(name, value, days, prefix) {
+        var expires,
+        prefix = prefix || "",
+        name = prefix + name;
         if (days) {
           var date = new Date();
           date.setTime(date.getTime()+(days*24*60*60*1000));
@@ -347,8 +367,10 @@ var Shareabouts = Shareabouts || {};
         }
         document.cookie = name+'='+value+expires+'; path=/';
       },
-      get: function(name) {
-        var nameEQ = name + '=';
+      get: function(name, prefix) {
+        var nameEQ = prefix + name + '=',
+        prefix = prefix || "",
+        ca = document.cookie.split(';');
         var ca = document.cookie.split(';');
         for(var i=0;i < ca.length;i++) {
           var c = ca[i];
@@ -363,6 +385,29 @@ var Shareabouts = Shareabouts || {};
       },
       destroy: function(name) {
         this.save(name,'',-1);
+      }
+    },
+
+    localstorage: {
+      LOCALSTORAGE_PREFIX: "mapseed-",
+      save: function(name, value, days) {
+        var expDate = new Date();
+        expDate.setTime(expDate.getTime() + (days * 24 * 60 * 60 * 1000));
+        localStorage.setItem(this.LOCALSTORAGE_PREFIX + name, JSON.stringify({
+          expires: expDate,
+          value: value
+        }));
+      },
+      get: function(name) {
+        var now = new Date().getTime(),
+        name = this.LOCALSTORAGE_PREFIX + name,
+        item = JSON.parse(localStorage.getItem(name)) || {};
+        if (now > Date.parse(item.expires)) {
+          localStorage.removeItem(name);
+          return null;
+        }
+
+        return item.value;
       }
     },
 

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -550,7 +550,7 @@ var Shareabouts = Shareabouts || {};
       }
 
       this.$panel.removeClass().addClass('place-form');
-      this.showPanel(this.placeFormView.render().$el);
+      this.showPanel(this.placeFormView.render(false).$el);
       this.placeFormView.postRender();
 
       this.placeFormView.delegateEvents();

--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -16,6 +16,7 @@ var Shareabouts = Shareabouts || {};
       var self = this;
        
       this.resetFormState();
+      this.placeDetail = this.options.placeConfig.place_detail;
 
       S.TemplateHelpers.overridePlaceTypeConfig(this.options.placeConfig.items,
         this.options.defaultPlaceTypeName);
@@ -23,34 +24,33 @@ var Shareabouts = Shareabouts || {};
     },
     resetFormState: function() {
       this.formState = {
-        selectedCategory: null,
-        selectedDatasetId: null,
-        selectedDatasetSlug: null,
+        selectedCategoryConfig: {
+          fields: []
+        },
         isSingleCategory: false,
         attachmentData: null,
-        placeDetail: this.options.placeConfig.place_detail
+        commonFormElements: this.options.placeConfig.common_form_elements || {}
       }
     },
-    render: function(category, isCategorySelected) {
+    render: function(isCategorySelected) {
       var self = this,
-      selectedCategoryConfig = category && _.find(self.formState.placeDetail, function(categoryConfig) { return categoryConfig.category === category; }) || {},
-      placesToIncludeOnForm = _.filter(self.formState.placeDetail, function(categoryConfig) { return categoryConfig.includeOnForm; });
+      placesToIncludeOnForm = _.filter(this.placeDetail, function(place) { 
+        return place.includeOnForm; 
+      });
 
       // if there is only one place to include on form, skip category selection page
       if (placesToIncludeOnForm.length === 1) {
         this.formState.isSingleCategory = true;
         isCategorySelected = true;
-        category = placesToIncludeOnForm[0].category;
-        this.formState.selectedCategory = category;
-        this.formState.selectedDatasetId = placesToIncludeOnForm[0].dataset;
-        this.formState.selectedDatasetSlug = _.find(this.options.mapConfig.layers, function(layer) { return self.formState.selectedDatasetId == layer.id }).slug;
-        selectedCategoryConfig = placesToIncludeOnForm[0];
+        this.formState.selectedCategoryConfig = placesToIncludeOnForm[0];
       }
+
+      this.checkAutocomplete();
 
       var data = _.extend({
         isCategorySelected: isCategorySelected,
         placeConfig: this.options.placeConfig,
-        selectedCategory: selectedCategoryConfig,
+        selectedCategoryConfig: this.formState.selectedCategoryConfig,
         user_token: this.options.userToken,
         current_user: S.currentUser,
         isSingleCategory: this.formState.isSingleCategory
@@ -74,6 +74,19 @@ var Shareabouts = Shareabouts || {};
         $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
       }
     },
+    checkAutocomplete: function() {
+      var self = this,
+      storedValue;
+
+      this.formState.selectedCategoryConfig.fields.forEach(function(field, i) {
+        storedValue = S.Util.getAutocompleteValue(field.name);
+        self.formState.selectedCategoryConfig.fields[i].autocompleteValue = storedValue || null;
+      });
+      this.formState.commonFormElements.forEach(function(field, i) {
+        storedValue = S.Util.getAutocompleteValue(field.name);
+        self.formState.commonFormElements[i].autocompleteValue = storedValue || null;
+      });
+    },
     remove: function() {
       this.unbind();
     },
@@ -90,7 +103,8 @@ var Shareabouts = Shareabouts || {};
       this.location = location;
     },
     getAttrs: function() {
-      var attrs = {},
+      var self = this,
+          attrs = {},
           locationAttr = this.options.placeConfig.location_item_name,
           $form = this.$('form');
 
@@ -100,6 +114,17 @@ var Shareabouts = Shareabouts || {};
       // get values off of binary toggle buttons that have not been toggled
       $.each($("input[data-input-type='binary_toggle']:not(:checked)"), function() {
         attrs[$(this).attr("name")] = $(this).val();
+      });
+
+      _.each(attrs, function(value, key) {
+        var itemConfig = _.find(
+          self.formState.selectedCategoryConfig.fields
+            .concat(self.formState.commonFormElements), function(field) { 
+              return field.name === key;
+            }) || {};
+        if (itemConfig.autocomplete) {
+          S.Util.saveAutocompleteValue(key, value, 30);
+        }
       });
 
       // Get the location attributes from the map
@@ -118,12 +143,12 @@ var Shareabouts = Shareabouts || {};
       var self = this,
           animationDelay = 400;
 
-      this.formState.selectedCategory = $(evt.target).parent().prev().attr('id');
-      this.formState.selectedDatasetId = _.find(self.formState.placeDetail, function(categoryConfig) { return categoryConfig.category === self.formState.selectedCategory }).dataset;
-      this.formState.selectedDatasetSlug = _.filter(this.options.mapConfig.layers, function(layer) { return layer.id === self.formState.selectedDatasetId })[0].slug;
+      this.formState.selectedCategoryConfig = _.find(this.placeDetail, function(place) {
+        return place.category == $(evt.target).parent().prev().attr('id');
+      });
 
       // re-render the form with the selected category
-      this.render(this.formState.selectedCategory, true);
+      this.render(true);
       // manually set the category button again since the re-render resets it
       $(evt.target).parent().prev().prop("checked", true);
       // hide and then show (with animation delay) the selected category button 
@@ -182,10 +207,10 @@ var Shareabouts = Shareabouts || {};
       var self = this,
       targetButton = $(evt.target).attr("id"),
       oldValue = $(evt.target).val(),
-      // find the matching config data for this element
-      selectedCategoryConfig = _.find(this.formState.placeDetail, function(categoryConfig) { return categoryConfig.category === self.formState.selectedCategory; }),
-      altData = _.find(selectedCategoryConfig.fields, function(item) { return item.name === targetButton; }),
-      // fetch alternate label and value
+      altData = _.find(this.formState.selectedCategoryConfig.fields
+        .concat(self.formState.commonFormElements), function(item) { 
+          return item.name === targetButton; 
+        }),
       altContent = _.find(altData.content, function(item) { return item.value != oldValue; });
 
       // set new value and label
@@ -218,7 +243,7 @@ var Shareabouts = Shareabouts || {};
 
       var self = this,
           router = this.options.router,
-          collection = this.collection[self.formState.selectedDatasetId],
+          collection = this.collection[self.formState.selectedCategoryConfig.dataset],
           model,
           // Should not include any files
           attrs = this.getAttrs(),
@@ -226,11 +251,13 @@ var Shareabouts = Shareabouts || {};
           spinner, $fileInputs;
       evt.preventDefault();
 
-      collection.add({"location_type": this.formState.selectedCategory});
+      collection.add({"location_type": this.formState.selectedCategoryConfig.category});
       model = collection.at(collection.length - 1);
 
-      model.set("datasetSlug", self.formState.selectedDatasetSlug);
-      model.set("datasetId", self.formState.selectedDatasetId);
+      model.set("datasetSlug", _.find(this.options.mapConfig.layers, function(layer) { 
+        return self.formState.selectedCategoryConfig.dataset == layer.id;
+      }).slug);
+      model.set("datasetId", self.formState.selectedCategoryConfig.dataset);
       
       // if an attachment has been added...
       if (self.formState.attachmentData) {

--- a/src/sa_web/static/scss/_forms.scss
+++ b/src/sa_web/static/scss/_forms.scss
@@ -122,3 +122,7 @@ select {
 .alt-label {
     display: none;
 }
+
+.isAutocomplete {
+    background-color: #ffffe0;
+}


### PR DESCRIPTION
**NOTE:** This PR replicates the same functionality added to the `develop` branch via #543 and #534.

This PR adds dynamic form autocompletion to the `pboakland` flavor. To use the autocomplete feature, add an `autocomplete: true` flag to each form field you'd like tracked. Fields that do not have this flag will not be tracked.

A few notes:
* Autocomplete fields are not category-specific. In other words, if a field with the same name (say, `description`) exists in multiple dynamic form categories, all instances of this field will be autocompleted if a stored value for that field name is found.
* Autocomplete data is stored in localStorage unless localStorage is not available, in which case cookies will be used.
* A light yellow background color is added to form fields that are populated with autocomplete values. To change this style behavior, override the `.isAutocomplete` CSS selector in `custom.css`. For example:
```
.isAutocomplete {
   background-color: white;
}
```
* Autocomplete data will expire and be deleted after 30 days.