### PR TITLE
Pass reset: true option to map.fitBounds() and map.setView()

### DIFF
--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -651,7 +651,7 @@ var Shareabouts = Shareabouts || {};
                 // TODO(Trevor): this needs to be cleaned up
                 self.setStoryLayerVisibility(model);
                 self.isProgrammaticZoom = true;
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
+                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
               } else {
                 map.setView(center, map.getMaxZoom()-1, {reset: true});
               }
@@ -664,9 +664,9 @@ var Shareabouts = Shareabouts || {};
               // if this model is part of a story, set center and zoom level
               self.isProgrammaticZoom = true;
               self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
+              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
             } else {
-              map.panTo(center, {animate: true});
+              map.panTo(center, {animate: true, reset: true});
             }
           }
         }
@@ -816,7 +816,7 @@ var Shareabouts = Shareabouts || {};
                 // TODO(Trevor): this needs to be cleaned up
                 self.isProgrammaticZoom = true;
                 self.setStoryLayerVisibility(model);
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
+                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
               } else {
                 map.setView(center, map.getMaxZoom()-1, {reset: true});
               }
@@ -828,9 +828,9 @@ var Shareabouts = Shareabouts || {};
             if (model.attributes.story) {
               self.isProgrammaticZoom = true;
               self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true});
+              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
             } else {
-              map.panTo(center, {animate: true});
+              map.panTo(center, {animate: true, reset: true});
             }
           }
         }


### PR DESCRIPTION
Passing the reset option seems to eliminate the problem of directly-loaded
landmarks causing a portion of the map to initially not be rendered and the
center of the map to be displayed incorrectly.

Fixes: #504