### PR TITLE
Call resetFormState() in PlaceFormView on route events

### DIFF
--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -16,6 +16,7 @@ var Shareabouts = Shareabouts || {};
       var self = this;
        
       this.resetFormState();
+      this.options.router.on("route", this.resetFormState, this);
       this.placeDetail = this.options.placeConfig.place_detail;
 
       S.TemplateHelpers.overridePlaceTypeConfig(this.options.placeConfig.items,


### PR DESCRIPTION
Make sure we reset the dynamic form state if we navigate away from
a rendered form (say, to the list view). Otherwise, it's possible
to corrupt the form's state by returning to the form after navigating
away.