### PR TITLE
Refactor place/landmark loading, support landmark-style urls

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -79,9 +79,16 @@ map:
       type: place
       slug: vision
 
+    # - id: restoration
+    #   type: place
+    #   slug: restoration
+
     - id: restoration
-      type: place
-      slug: restoration
+      url: https://k7b7dyc4v3.execute-api.us-west-2.amazonaws.com/production/getLandmarks
+      type: landmark
+      sources:
+        - "http://a.tiles.mapbox.com/v4/smartercleanup.k9dcl2i9/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
+        - "http://a.tiles.mapbox.com/v4/smartercleanup.1pbl473a/features.json?access_token=pk.eyJ1Ijoic21hcnRlcmNsZWFudXAiLCJhIjoiTnFhUWc2cyJ9.CqPJH-9yspIMudowQJx2Uw"
 
     - id: trees
       type: place
@@ -1561,7 +1568,10 @@ story:
     default_zoom: 17
     default_visible_layers:
       - restoration
+      - trees
     order:
+      - url: trees/187
+      - url: trees/276
       - url: marra
       - url: skatepark
       - url: concord

--- a/src/sa_web/jstemplates/activity-list-item.html
+++ b/src/sa_web/jstemplates/activity-list-item.html
@@ -1,6 +1,6 @@
       <li class="activity-item clearfix">
         {{!-- data attributes are not ideal, see comment in activity view --}}
-        <a href="/{{ place.datasetSlug }}/{{ place.id }}{{#is target_type 'comments'}}/response/{{ target.id }}{{/is}}" data-action-type="{{ target_type }}" data-place-id="{{ place.id }}">{{#_}}<strong>
+        <a href="/{{#if place.url-title}}{{ place.url-title }}{{else}}{{ place.datasetSlug }}/{{ place.id }}{{/if}}{{#is target_type 'comments'}}/response/{{ target.id }}{{/is}}" data-action-type="{{ target_type }}" data-place-id="{{ place.id }}">{{#_}}<strong>
 
         {{#if target.submitter.avatar_url}}
           <img src="{{ target.submitter.avatar_url }}" class="avatar" />

--- a/src/sa_web/jstemplates/place-detail.html
+++ b/src/sa_web/jstemplates/place-detail.html
@@ -45,13 +45,15 @@
                 in {{ region }}
               {{/if}}{{/_}}
 
-              <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{ datasetSlug }}/{{ id }}">{{ fromnow created_datetime }}</a></time>
+              <time datetime="{{ created_datetime }}" class="response-date"><a href="/{{#if url-title}}{{ url-title }}{{else}}{{ datasetSlug }}/{{ id }}{{/if}}">{{ fromnow created_datetime }}</a></time>
 
               <span class="survey-count">{{ survey_count }} {{ survey_label_by_count }}</span>
             {{/is_not}}
 
           {{^if survey_config}}
-            <a rel="internal" href="/{{ datasetSlug }}/{{ id }}" class="view-on-map-btn btn btn-small">View On Map</a>
+            <a rel="internal" 
+               href="/{{#if url-title}}{{ url-title }}{{else}}{{ datasetSlug }}/{{ id }}{{/if}}"
+               class="view-on-map-btn btn btn-small">View On Map</a>
           {{/if}}
 
           </span>

--- a/src/sa_web/static/js/routes.js
+++ b/src/sa_web/static/js/routes.js
@@ -11,6 +11,7 @@ var Shareabouts = Shareabouts || {};
       ':dataset/:id': 'viewPlace',
       'new': 'newPlace',
       ':dataset/:id/response/:response_id': 'viewPlace',
+      ':id/response/:response_id': 'viewLandmark',
       ':dataset/:id/edit': 'editPlace',
       'list': 'showList',
       ':id': 'viewLandmark',
@@ -183,12 +184,21 @@ var Shareabouts = Shareabouts || {};
       this.appView.newPlace();
     },
 
-    viewLandmark: function(id) {
-      this.appView.viewLandmark(id, { zoom: this.loading });
+    viewLandmark: function(modelId, responseId) {
+      this.appView.viewPlaceOrLandmark({
+        modelId: modelId,
+        responseId: responseId,
+        loading: this.loading
+      });
     },
 
-    viewPlace: function(datasetSlug, id, responseId) {
-      this.appView.viewPlace(datasetSlug, id, responseId, this.loading);
+    viewPlace: function(datasetSlug, modelId, responseId) {      
+      this.appView.viewPlaceOrLandmark({
+        datasetSlug: datasetSlug,
+        modelId: modelId,
+        responseId: responseId,
+        loading: this.loading
+      });
     },
 
     editPlace: function(){},

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -470,6 +470,8 @@ var Shareabouts = Shareabouts || {};
         delete this.placeDetailViews[model.cid];
       }
     },
+
+    // TODO: clean up landmark/place distinction here
     getLandmarkDetailView: function(collectionId, model) {
       var landmarkDetailView;
       if (this.landmarkDetailViews[collectionId] && this.landmarkDetailViews[collectionId][model.id]) {
@@ -503,8 +505,9 @@ var Shareabouts = Shareabouts || {};
           userToken: this.options.userToken,
           mapView: this.mapView,
           router: this.options.router,
-          url: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).url,
-          datasetId: _.find(this.options.mapConfig.layers, function(layer) { return layer.slug == model.attributes.datasetSlug }).id
+          datasetId: _.find(this.options.mapConfig.layers, function(layer) { 
+            return layer.slug == model.attributes.datasetSlug 
+          }).id
         });
         this.placeDetailViews[model.cid] = placeDetailView;
       }
@@ -613,236 +616,79 @@ var Shareabouts = Shareabouts || {};
         });
       });
     },
-
-    // TODO: Refactor this into 'viewPlace'
-    viewLandmark: function(model, options) {
+    viewPlaceOrLandmark: function(args) {
       var self = this,
-          includeSubmissions = S.Config.flavor.app.list_enabled !== false,
-          layout = S.Util.getPageLayout(),
-          onLandmarkFound, onLandmarkNotFound, modelId;
+        includeSubmissions = S.Config.flavor.app.list_enabled !== false,
+        layout = S.Util.getPageLayout(),
+        onFound, onNotFound, searchLoadedCollections, createCollectionsListeners,
+        foundInCallback = false;
 
-      onLandmarkFound = function(model, response, newOptions) {
+      onFound = function(model, type, datasetId) {
         var map = self.mapView.map,
-            layer, center, $responseToScrollTo;
-        options = newOptions ? newOptions : options;
+          layer, center, zoom, detailView, $responseToScrollTo;
 
-        layer = self.mapView.layerViews[options.collectionId][model.id].layer
-
-        if (layer) {
-          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
-        }
-        self.activeDetailView = self.getLandmarkDetailView(options.collectionId, model);
-        self.activeDetailView.isModified = false;
-        self.activeDetailView.isEditingToggled = false;
-
-        self.$panel.removeClass().addClass('place-detail place-detail-' + model);
-        self.showPanel(self.activeDetailView.render().$el, false);
-        self.activeDetailView.delegateEvents();
-
-        self.hideNewPin();
-        self.destroyNewModels();
-        self.hideCenterPoint();
-        self.setBodyClass('content-visible');
-
-        if (layer) {
-          if (options.zoom) {
-            if (layer.getLatLng) {
-              if (model.attributes.story) {
-                // TODO(Trevor): this needs to be cleaned up
-                self.setStoryLayerVisibility(model);
-                self.isProgrammaticZoom = true;
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
-              } else {
-                map.setView(center, map.getMaxZoom()-1, {reset: true});
-              }
-            } else {
-              map.fitBounds(layer.getBounds(), {reset: true});
-            }
-
-          } else {
-            if (model.attributes.story) {
-              // if this model is part of a story, set center and zoom level
-              self.isProgrammaticZoom = true;
-              self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
-            } else {
-              map.panTo(center, {animate: true, reset: true});
-            }
+        if (type === "place") {
+          // If this model is a duplicate of one that already exists in the
+          // places collection, it may not correspond to a layerView. For this
+          // case, get the model that's actually in the places collection.
+          if (_.isUndefined(self.mapView.layerViews[model.cid])) {
+            model = self.places[datasetId].get(model.id);
           }
-        }
-        self.addSpotlightMask();
 
-        // Focus the one we're looking
-        model.trigger('focus');
-
-        if (model.get("story")) {
-          if (!model.get("story").spotlight) $("#spotlight-place-mask").remove();
-          self.isStoryActive = true;
-          self.setStoryLayerVisibility(model);
-        } else if (self.isStoryActive) {
-          self.isStoryActive = false;
-          self.restoreDefaultLayerVisibility();
-        } else {
-          self.isStoryActive = false;
-        }
-      };
-
-      onLandmarkNotFound = function(model, response, newOptions) {
-        options.stillSearching[options.collectionId] = false;
-        var allCollectionsSearched = true;
-        _.each(_.values(options.stillSearching), function(stillSearching) {
-          if (stillSearching) {
-            allCollectionsSearched = false;
+          // TODO: We need to handle the non-deterministic case when
+          // 'self.mapView.layerViews[datasetId][model.cid]` is undefined -- ????
+          if (self.mapView.layerViews[datasetId] 
+            && self.mapView.layerViews[datasetId][model.cid]) {
+            layer = self.mapView.layerViews[datasetId][model.cid].layer;
           }
-        });
-        if (allCollectionsSearched) {
-          self.options.router.navigate('/');
+
+          detailView = self.getPlaceDetailView(model).delegateEvents();
+          self.showPanel(detailView.render().$el, !!args.responseId);
+        } else if (type === "landmark") {
+          layer = self.mapView.layerViews[datasetId][model.id].layer;
+          detailView = self.getLandmarkDetailView(datasetId, model).delegateEvents();
+          self.showPanel(detailView.render().$el, false);
         }
-      };
-
-      // If a collectionId is not specified, then we need to search all collections
-      if (options['collectionId'] === undefined) {
-        // First, let's check the caches of all of our collections for the
-        // model to avoid making unnecessary api calls for each collection:
-        var cachedModel;
-        var collectionId;
-
-        _.find(Object.keys(self.options.landmarks), function(landmarkConfigId) {
-          collectionId = landmarkConfigId;
-          cachedModel = self.landmarks[collectionId].get(model);
-          return cachedModel;
-        });
-        if (cachedModel) {
-          onLandmarkFound(cachedModel, {}, { collectionId: collectionId,
-                                          zoom: options.zoom });
-          return;
-        }
-
-        // If the model is not already in our collections, then we must fetch it
-        // by making a call to each collection:
-        var stillSearching = {};
-        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
-          stillSearching[landmarkConfig.id] = true;
-        });
-        _.each(self.options.datasetConfigs.landmarks, function(landmarkConfig) {
-          self.viewLandmark(model, { collectionId: landmarkConfig.id,
-                                     zoom: options.zoom,
-                                     stillSearching: stillSearching });
-        });
-        return;
-      }
-
-      // If we are passed a LandmarkModel then show it immediately.
-      if (model instanceof S.LandmarkModel) {
-        onLandmarkFound(model)
-        return;
-      }
-
-      // Otherwise, assume we have a model ID.
-      modelId = model;
-      var landmarkCollection = this.landmarks[options.collectionId];
-      if (!landmarkCollection) {
-        onLandmarkNotFound();
-        return;
-      }
-      model = landmarkCollection.get(modelId);
-
-      // If the model was found in the landmarks, go ahead and use it.
-      if (model) {
-        onLandmarkFound(model);
-
-      // Otherwise, fetch and use the result.
-      } else {
-        landmarkCollection.fetch({
-          success: function(collection, response, options) {
-            var foundModel = collection.findWhere({ id: modelId });
-            if (foundModel) {
-              onLandmarkFound(foundModel);
-            } else {
-              onLandmarkNotFound();
-            }
-          },
-          error: onLandmarkNotFound
-        })
-      }
-    },
-    viewPlace: function(datasetSlug, model, responseId, zoom) {
-      var self = this,
-          includeSubmissions = S.Config.flavor.app.list_enabled !== false,
-          layout = S.Util.getPageLayout(),
-          // get the dataset id from the map layers array for the given datasetSlug
-          datasetId = _.find(self.options.mapConfig.layers, function(layer) { return layer.slug == datasetSlug }).id,
-          onPlaceFound, onPlaceNotFound, modelId;
-
-      onPlaceFound = function(model) {
-        var map = self.mapView.map,
-            layer, center, $responseToScrollTo;
-
-        // If this model is a duplicate of one that already exists in the
-        // places collection, it may not correspond to a layerView. For this
-        // case, get the model that's actually in the places collection.
-        if (_.isUndefined(self.mapView.layerViews[model.cid])) {
-          model = self.places[datasetId].get(model.id);
-        }
-
-        // TODO: We need to handle the non-deterministic case when
-        // 'self.mapView.layerViews[model.cid]` is undefined
-        if (self.mapView.layerViews[datasetId] && self.mapView.layerViews[datasetId][model.cid]) {
-          layer = self.mapView.layerViews[datasetId][model.cid].layer;
-        }
-
-        self.activeDetailView = self.getPlaceDetailView(model);
-        self.activeDetailView.isModified = false;
-        self.activeDetailView.isEditingToggled = false;
-
-        if (layer) {
-          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
-        }
-
+     
         self.$panel.removeClass().addClass('place-detail place-detail-' + model.id);
-        self.showPanel(self.activeDetailView.render().$el, !!responseId);
-        self.activeDetailView.delegateEvents();
-        // TODO(Trevor): prevent default form behavior when in editing mode
-
         self.hideNewPin();
         self.destroyNewModels();
         self.hideCenterPoint();
         self.setBodyClass('content-visible');
-
-        if (layer) {
-          if (zoom) {
-            if (layer.getLatLng) {
-              if (model.attributes.story) {
-                // TODO(Trevor): this needs to be cleaned up
-                self.isProgrammaticZoom = true;
-                self.setStoryLayerVisibility(model);
-                map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
-              } else {
-                map.setView(center, map.getMaxZoom()-1, {reset: true});
-              }
-            } else {
-              map.fitBounds(layer.getBounds(), {reset: true});
-            }
-
-          } else {
-            if (model.attributes.story) {
-              self.isProgrammaticZoom = true;
-              self.setStoryLayerVisibility(model);
-              map.setView(model.attributes.story.panTo || center, model.attributes.story.zoom, {animate: true, reset: true});
-            } else {
-              map.panTo(center, {animate: true, reset: true});
-            }
-          }
-        }
         self.addSpotlightMask();
 
-        if (responseId) {
-          // get the element based on the id
-          $responseToScrollTo = self.activeDetailView.$el.find('[data-response-id="'+ responseId +'"]');
+        if (layer) {
+          center = layer.getLatLng ? layer.getLatLng() : layer.getBounds().getCenter();
+          zoom = map.getZoom();
+          
+          if (model.get("story")) {
+            if (!model.get("story").spotlight) {
+              $("#spotlight-place-mask").remove();
+            }
+            self.isStoryActive = true;
+            self.isProgrammaticZoom = true;
+            self.setStoryLayerVisibility(model);
+            center = model.get("story").panTo || center;
+            zoom = model.get("story").zoom;
+          }
 
-          // call scrollIntoView()
+          if (layer.getLatLng) {
+            map.setView(center, zoom, {
+              animate: true,
+              reset: (args.loading) ? true : false
+            });
+          } else {
+            map.fitBounds(layer.getBounds(), {
+              animate: true,
+              reset: (args.loading) ? true : false
+            });
+          }
+        }
+
+        if (args.responseId) {
+          $responseToScrollTo = detailView.$el.find('[data-response-id="'+ args.responseId +'"]');
           if ($responseToScrollTo.length > 0) {
-            if (layout === 'desktop') {
+            if (layout === '"desktop"') {
               // For desktop, the panel content is scrollable
               self.$panelContent.scrollTo($responseToScrollTo, 500);
             } else {
@@ -852,52 +698,100 @@ var Shareabouts = Shareabouts || {};
           }
         }
 
-        // Focus the one we're looking
         model.trigger('focus');
-
-        if (model.get("story")) {
-          if (!model.get("story").spotlight) $("#spotlight-place-mask").remove();
-          self.isStoryActive = true;
-          self.setStoryLayerVisibility(model);
-        } else if (self.isStoryActive) {
+        
+        if (!model.get("story") && self.isStoryActive) {
           self.isStoryActive = false;
           self.restoreDefaultLayerVisibility();
-        } else {
-          self.isStoryActive = false;
         }
       };
 
-      onPlaceNotFound = function() {
+      onNotFound = function() {
         self.options.router.navigate('/');
+        return;
       };
 
-      // If we get a PlaceModel then show it immediately.
-      if (model instanceof S.PlaceModel) {
-        onPlaceFound(model);
-        return;
-      }
-
-      // Otherwise, assume we have a model ID.
-      modelId = model;
-      model = this.places[datasetId].get(modelId);
-
-      // If the model was found in the places, go ahead and use it.
-      if (model) {
-        onPlaceFound(model);
-
-      // Otherwise, fetch and use the result.
-      } else {
-        this.places[datasetId].fetchById(modelId, {
-          // Check for a valid location type before adding it to the collection
-          validate: true,
-          success: onPlaceFound,
-          error: onPlaceNotFound,
-          data: {
-            include_submissions: includeSubmissions
+      searchLoadedCollections = function(collections, property, type) {
+        var found = false,
+        searchTerm = {};
+        searchTerm[property] = args.modelId;
+        _.find(collections, function(collection, datasetId) {
+          var model = collection.where(searchTerm);
+          if (model.length === 1) {
+            found = true;
+            onFound(model[0], type, datasetId);
+            return;
           }
         });
+
+        return found;
+      };
+
+      bindCollectionsListeners = function(collections, property, type, finalCollection) {
+        var numCollections = _.keys(collections).length,
+        i = 0,
+        searchTerm = {};
+        searchTerm[property] = args.modelId;
+        _.each(collections, function(collection, datasetId) {
+          collection.on("sync", function(syncedCollection) {
+            i++;
+            var model = syncedCollection.where(searchTerm);
+            if (model.length === 1) {
+              foundInCallback = true;
+              onFound(model[0], type, datasetId);
+            } else if (numCollections === i && finalCollection && !foundInCallback) {
+              // if this is the last collection of the set and the final
+              // set of collections and no model has been found, it means the
+              // model doesn't exist.
+              onNotFound();
+            }
+          });
+        });
+      };
+
+      if (args.datasetSlug) {
+        // If we have a slug, we definitely have a place model
+        var datasetId = _.find(self.options.mapConfig.layers, function(layer) { 
+          return layer.slug === args.datasetSlug;
+        }).id;
+        model = this.places[datasetId].get(args.modelId);
+        if (model) {
+          onFound(model, "place", datasetId);
+          return;
+        } else {
+          this.places[datasetId].fetchById(args.modelId, {
+            validate: true,
+            success: function(model) {
+              onFound(model, "place", datasetId);
+              return;
+            },
+            error: function() {
+              onNotFound();
+              return;
+            },
+            data: {
+              include_submissions: includeSubmissions
+            }
+          });
+        }
+      } else {
+        // Otherwise, we have a landmark-style url, which may correspond
+        // to a place or a landmark.
+        // Conduct a search according to the following strategy: 
+        // 1. check loaded place collections
+        // 2. check loaded landmark collections
+        // 3. set up sync listeners on all place and landmark collections
+        if (searchLoadedCollections(this.places, "url-title", "place")) {
+          return;
+        };
+        if (searchLoadedCollections(this.landmarks, "id", "landmark")) {
+          return;
+        };
+        bindCollectionsListeners(this.places, "url-title", "place", false);
+        bindCollectionsListeners(this.landmarks, "id", "landmark", true);
       }
     },
+
     viewPage: function(slug) {
       var pageConfig = S.Util.findPageConfig(this.options.pagesConfig, {slug: slug}),
           pageTemplateName = 'pages/' + (pageConfig.name || pageConfig.slug),
@@ -911,6 +805,7 @@ var Shareabouts = Shareabouts || {};
       this.hideCenterPoint();
       this.setBodyClass('content-visible');
     },
+
     showPanel: function(markup, preventScrollToTop) {
       var map = this.mapView.map;
 

--- a/src/sa_web/static/js/views/layer-view.js
+++ b/src/sa_web/static/js/views/layer-view.js
@@ -121,9 +121,13 @@ var Shareabouts = Shareabouts || {};
     },
     onMarkerClick: function() {
       S.Util.log('USER', 'map', 'place-marker-click', this.model.getLoggingDetails());
-      this.options.router.navigate('/' + this.model.get('datasetSlug') + '/' + this.model.id, {trigger: true});
+      // support places with landmark-style urls
+      if (this.model.get("url-title")) {
+        this.options.router.navigate('/' + this.model.get("url-title"), {trigger: true});
+      } else {
+        this.options.router.navigate('/' + this.model.get('datasetSlug') + '/' + this.model.id, {trigger: true});
+      }      
     },
-
     isPoint: function() {
       return this.model.get('geometry').type == 'Point';
     },

--- a/src/sa_web/static/js/views/place-detail-view.js
+++ b/src/sa_web/static/js/views/place-detail-view.js
@@ -106,7 +106,6 @@ var Shareabouts = Shareabouts || {};
           data = _.extend({
             place_config: this.options.placeConfig,
             survey_config: this.options.surveyConfig,
-            url: this.options.url,
             isEditable: self.isEditable || false,
             isEditingToggled: self.isEditingToggled || false
           }, this.model.toJSON());


### PR DESCRIPTION
Addresses: #527, #549 

This PR is a major refactor of the code that loads places and landmarks. Changes include:

- Support for places with landmark-style urls. If a place model has a field called `url-title`, the value of this field will correspond to the place's url in the app. The underlying Shareabouts-style url will not be used.
- Reduced code duplication and complexity in the AppView. We now have a single `viewPlaceOrLandmark()` method, which accommodates loading from traditional place urls (`report/342`), landmark urls (`/landmark`), and places with landmark-style urls.
- Slight loading performance boost on direct url loads. We might experience quicker load times when we load the app directly to a place or landmark url.

