### PR TITLE
Detect if category is selected in place form view postRender()

### DIFF
--- a/src/sa_web/static/js/views/place-form-view.js
+++ b/src/sa_web/static/js/views/place-form-view.js
@@ -64,12 +64,12 @@ var Shareabouts = Shareabouts || {};
       return this;
     },
     // called from the app view
-    postRender: function() {
+    postRender: function(isCategorySelected) {
       var self = this,
       $prompt;
 
       $('#datetimepicker').datetimepicker({ formatTime: 'g:i a' });
-      if ($(".rawHTML").length > 0) {
+      if (isCategorySelected && $(".rawHTML").length > 0) {
         // NOTE: we currently support a single QuillJS field per form
         $prompt = $(".rawHTML").find("label").detach();
 
@@ -177,7 +177,7 @@ var Shareabouts = Shareabouts || {};
       });
 
       this.render(true);
-      this.postRender();
+      this.postRender(true);
       $(evt.target).parent().prev().prop("checked", true);
       $("#selected-category").hide().show(animationDelay);
       $("#category-btns").animate( { height: "hide" }, animationDelay );


### PR DESCRIPTION
Fixes a bug that occurs when the dynamic form is show after a Quill editor has been rendered in a place detail view in edit mode.