### PR TITLE
Add configurable right-panel activity stream

### DIFF
--- a/src/flavors/duwamish_flavor/config.yml
+++ b/src/flavors/duwamish_flavor/config.yml
@@ -670,6 +670,10 @@ activity:
   enabled: true
   # How often to refresh the activity list, in milliseconds.
   interval: 30000
+  # To show the activity stream in the right panel, set this flag to true.
+  # To also remove it from the leaflet controls, comment out the "id: ticker"
+  # entry in the leaflet control config above.
+  show_in_right_panel: false
 
   # Place Types
 

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -1840,6 +1840,16 @@ a.auth-inline {
   padding: 6px 10px 5px 6px;
 }
 
+.right-sidebar-visible #right-sidebar {
+  position: absolute;
+  right: 0;
+  width: 20%;
+  max-height: 100%;
+  overflow: auto;
+  box-shadow: -0.325em 0 0 rgba(0, 0, 0, 0.1);
+  z-index: 10;
+}
+
 #ticker {
   background: url(images/lightpaperfibers.png);
   z-index: 30;
@@ -1851,6 +1861,7 @@ a.auth-inline {
 
 .activity-enabled #ticker {
   display: block;
+  width: 40%;
 }
 
 ul.recent-points {
@@ -2427,8 +2438,24 @@ a.close-unsupported-overlay {
     height: calc(100% - 72px);
   }
 
+  .right-sidebar-visible #map-container {
+    height: 65%;
+  }
+
   .activity-enabled.content-visible #map-container {
     height: 70%;
+  }
+
+  .right-sidebar-visible #right-sidebar {
+    width: 100%;
+    display: block;
+    left: 0;
+    top: calc(65% + 72px);
+    height: 400px;
+  }
+
+  .content-visible.right-sidebar-visible #right-sidebar {
+    display: none;
   }
 }
 @media only screen and (min-width: 60em) {
@@ -2436,11 +2463,15 @@ a.close-unsupported-overlay {
     content: "desktop";
   }
 
+  #right-sidebar {
+    height: calc(100% - 64px - 0px);
+  }
+
   #site-header {
     background: url(images/lightpaperfibers.png);
     padding-left: 1em;
     overflow: visible;
-    height: 4em;
+    height: 64px;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -2579,10 +2610,6 @@ a.close-unsupported-overlay {
     width: 40%;
   }
 
-  .activity-enabled.content-visible #map-container {
-    width: 60%;
-  }
-
   .geocoding-bar-enabled #map-container {
     top: 8.5em;
   }
@@ -2642,11 +2669,18 @@ a.close-unsupported-overlay {
     padding: 0;
     position: absolute;
     top: 4em;
-    right: 0;
     bottom: 1.75em;
     overflow: visible;
     box-shadow: -0.325em 0 0 rgba(0, 0, 0, 0.1);
     width: 40%;
+  }
+
+  .content-visible #content {
+    right: 0;
+  }
+
+  .right-sidebar-visible.content-visible #content {
+    left: 40%;
   }
 
   .activity-enabled #content {
@@ -2660,6 +2694,14 @@ a.close-unsupported-overlay {
 
   .activity-enabled.content-visible #map-container {
     width: 60%;
+  }
+
+  .right-sidebar-visible #map-container {
+    width: 80%;
+  }
+
+  .right-sidebar-visible.content-visible #map-container {
+    width: 40%;
   }
 
   .geocoding-bar-enabled #content {

--- a/src/sa_web/static/js/views/app-view.js
+++ b/src/sa_web/static/js/views/app-view.js
@@ -62,6 +62,11 @@ var Shareabouts = Shareabouts || {};
         self.toggleListView();
       });
 
+      if (this.options.activityConfig.show_in_right_panel === true) {
+        this.setBodyClass("right-sidebar-visible");
+        $("#right-sidebar").html("<ul class='recent-points unstyled-list'></ul>");
+      }
+
       $(document).on('click', '.activity-item a', function(evt) {
         window.app.clearLocationTypeFilter();
       });

--- a/src/sa_web/static/scss/_media.scss
+++ b/src/sa_web/static/scss/_media.scss
@@ -58,26 +58,40 @@
 
 // Catchall media query for screen widths below 60em. Calculated screen heights
 // mean we don't need several media queries as above, and in general don't need
-// to worry about querying heights, but keeping the skeleton of those around in
-// case future design features require specific media queries.
-
+// to worry about querying heights.
 @media only screen and (max-width: 60em) {
     html, body, #map {
         height: 100%;
     }
 
     #main {
-        // calculated as 100% of viewport height minus the fixed pixel height of the header
-        height: calc(100% - 64px);
+        // calculated as 100% of viewport height, minus the height of the header
+        height: calc(100% - #{$header-height-fullscreen});
     }
 
     #map-container {
         // calculated as 100% of #main height minus the fixed pixel height of the footer
-        height: calc(100% - 72px);
+        height: calc(100% - #{$footer-height-smallscreen});
+    }
+
+    .right-sidebar-visible #map-container {
+        height: $map-height-smallscreen-when-sidebar-visible;
     }
 
     .activity-enabled.content-visible #map-container {
         height: 70%;
+    }
+
+    .right-sidebar-visible #right-sidebar {
+        width: 100%;
+        display: block;
+        left: 0;
+        top: calc(#{$map-height-smallscreen-when-sidebar-visible} + #{$footer-height-smallscreen});
+        height: 400px;
+    }
+
+    .content-visible.right-sidebar-visible #right-sidebar {
+        display: none;
     }
 }
 
@@ -88,12 +102,17 @@
         content: "desktop";
     }
 
+    // right sidebar
+    #right-sidebar {
+        height: calc(100% - #{$header-height-fullscreen} - #{$footer-height-fullscreen});
+    }
+
     // Header
     #site-header {
         background: url(images/lightpaperfibers.png);
         padding-left: 1em;
         overflow: visible;
-        height: 4em;
+        height: $header-height-fullscreen;
 
         // height of site-header
         -webkit-box-sizing: border-box;
@@ -256,10 +275,6 @@
         width: 40%;
     }
 
-    .activity-enabled.content-visible #map-container {
-        width: $map-width-when-content-visible;
-    }
-
     .geocoding-bar-enabled #map-container {
         top: 8.5em;
     }
@@ -332,13 +347,20 @@
         top: 4em;
 
         // height of site-header
-        right: 0;
         bottom: 1.75em;
 
         //left: 40%;
         overflow: visible;
         box-shadow: (-0.325em) 0 0 $opacity-very-low-black;
         width: $content-visible-width;
+    }
+
+    .content-visible #content {
+        right: 0;
+    }
+
+    .right-sidebar-visible.content-visible #content {
+        left: $content-visible-with-sidebar-left-offset;
     }
 
     .activity-enabled #content {
@@ -352,6 +374,14 @@
 
     .activity-enabled.content-visible #map-container {
         width: $map-width-when-content-visible;
+    }
+
+    .right-sidebar-visible #map-container {
+        width: $map-width-when-sidebar-visible;
+    }
+
+    .right-sidebar-visible.content-visible #map-container {
+        width: $map-width-when-content-and-sidebar-visible;
     }
 
     .geocoding-bar-enabled #content {

--- a/src/sa_web/static/scss/_sidebar.scss
+++ b/src/sa_web/static/scss/_sidebar.scss
@@ -55,3 +55,15 @@
 //font-family: 'Dancing Script', cursive;
 //text-shadow: 1px -1px 1px rgba(0,0,0,0.5);
 //}
+
+.right-sidebar-visible #right-sidebar {
+    position: absolute;
+    right: 0;
+    width: $sidebar-width;
+    max-height: 100%;
+    overflow: auto;
+    box-shadow: (-0.325em) 0 0 $opacity-very-low-black;
+    z-index: 10;
+    
+}
+

--- a/src/sa_web/static/scss/_ticker.scss
+++ b/src/sa_web/static/scss/_ticker.scss
@@ -14,6 +14,7 @@
 
 .activity-enabled #ticker {
     display: block;
+    width: 40%;
 }
 
 //.content-visible #ticker {

--- a/src/sa_web/static/scss/_variables.scss
+++ b/src/sa_web/static/scss/_variables.scss
@@ -45,6 +45,8 @@ $selected-message-dark-gray: #222222;
 // ################################
 // HEADER - VARIABLES
 // ################################
+$header-height-fullscreen: 64px;
+//$header-height-smallscreen: 50px; ??????
 // Navigation Button - Variables
 // Navigation Menu - Variables
 // User Menu - Variables
@@ -74,6 +76,7 @@ $selected-message-dark-gray: #222222;
 // ################################
 // SIDEBAR - VARIABLES
 // ################################
+$sidebar-width: 20%;
 
 // ################################
 // TICKER - VARIABLES
@@ -101,6 +104,8 @@ $selected-message-dark-gray: #222222;
 // ################################
 // FOOTER - VARIABLES
 // ################################
+$footer-height-fullscreen: 0px;
+$footer-height-smallscreen: 72px;
 // Powered By - Variables
 // Mapquest Attribution - Variables
 
@@ -112,5 +117,12 @@ $selected-message-dark-gray: #222222;
 // MEDIA QUERIES - VARIABLES
 // ################################
 $map-width-when-content-visible: 60%;
+$map-width-when-sidebar-visible: 80%;
+$map-width-when-content-and-sidebar-visible: 40%;
+$map-height-smallscreen-when-sidebar-visible: 65%;
+
 $content-visible-left-offset: $map-width-when-content-visible;
+$content-visible-with-sidebar-left-offset: $map-width-when-content-and-sidebar-visible;
+
 $content-visible-width: 100% - $map-width-when-content-visible;
+$content-with-sidebar-visible-width: 100% - $map-width-when-content-and-sidebar-visible - $sidebar-width;

--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -144,6 +144,8 @@
       <a href="#" class="close-btn">&#10005;<span>{% blocktrans %}Close{% endblocktrans %}</span></a>
       <article></article>
     </div><!-- end #content -->
+    <!-- right-panel sidebar -->
+    <div id="right-sidebar"></div>
   </div><!-- end #main -->
 
  {% if config.sidebar.enabled %}


### PR DESCRIPTION
Addresses: #561

This PR reinstates the old right-clinging sidebar with activity stream, but adds the ability to turn it on or off in the config. To turn the right-panel sidebar on, set the `show_in_right_panel` flag to `true` in the `activity` section of the config.

Note that to disable the leaflet control version of the activity stream, you'll need to comment out the `id: ticker` section of the leaflet control config. Otherwise, you'll have two activity streams, one in the leaflet controls and one in the right sidebar.